### PR TITLE
Add a generic node-style .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+.DS_Store
+._*
+.Trash*
+$*
+
+# Backup files
+*.sw[g-p]
+*.bak
+*~
+*#
+
+# IDEs
+*.as3proj
+.buildpath
+.c9revisions/
+.cproject
+.project
+.idea/
+.settings*
+.metadata/
+nbproject/
+
+# Generated
+/node_modules/


### PR DESCRIPTION
Hides Mac specific files, backup files, and lots of editor-specific things from git.  Also hides the node_modules folder.