### PR TITLE
Defaulting the port via environment variable

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,9 +1,17 @@
 "use strict";
 
-var container;
+var config, container, logger;
 
 container = require("../lib/dependencies");
 
-// Initialize the server and the health check endpoints
-container.resolve("ApiServer");
-container.resolve("HealthCheck");
+// Initialize the server
+config = container.resolve("config");
+logger = container.resolve("logger");
+
+// Allow overriding of the port
+if (process.env.PORT) {
+    logger.info("Environment variable overriding port (was " + config.server.port + ", is now " + process.env.PORT + ")");
+    config.server.port = process.env.PORT;
+}
+
+container.resolve("apiServer");


### PR DESCRIPTION
Cloud9 prefers you use the $PORT environment variable.  Altered the code so
that it detects when the PORT environment variable exists and will start the
server on that port instead of using the port number in the config.