### PR TITLE
Bugfix for Proxy Protocol - Adjusting how we wrap HTTP

### DIFF
--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -44,10 +44,6 @@ class WebServer {
      */
     app() {
         if (! this.application) {
-            if (this.config.proxyProtocol) {
-                this.proxywrap.proxy(this.http);
-            }
-
             this.application = this.express();
         }
 
@@ -77,7 +73,17 @@ class WebServer {
      * @return this
      */
     startServer() {
-        this.app().listen(this.config.port, () => {
+        var proxiedHttp, server;
+
+        if (this.config.proxyProtocol) {
+            this.logger.info("Enabling Proxy Protocol");
+            proxiedHttp = this.proxywrap.proxy(this.http);
+            server = proxiedHttp.createServer(this.app());
+        } else {
+            server = this.app();
+        }
+
+        server.listen(this.config.port, () => {
             this.logger.info("Server listening on port " + this.config.port);
         });
 


### PR DESCRIPTION
This works differently than I had previously understood.  With this adjustment the code works as expected.

Previously I thought this monkey patched `http`.  Now I understand that it doesn't alter the original object (the one from `require()` and instead gives us back a new one.