### PR TITLE
Updating Dizzy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "homepage": "https://github.com/opentoken-io/opentoken#readme",
     "devDependencies": {},
     "dependencies": {
-        "dizzy": "^1.0.1",
+        "dizzy": "^1.0.2",
         "express": "^4.13.4",
         "findhit-proxywrap": "^0.3.11"
     }


### PR DESCRIPTION
This bumps the version so the spread operator is not used in the library.  That, in turn, allows the code to run on a Cloud9 VM without using nvm to update Node.  It also allows the code to run in AWS through Elastic Beanstalk.