### PR TITLE
Flipping the library exports to export the class

### DIFF
--- a/lib/api-server.js
+++ b/lib/api-server.js
@@ -11,6 +11,4 @@ class ApiServer {
     }
 };
 
-module.exports = (container) => {
-    container.instance("apiServer", ApiServer);
-};
+module.exports = ApiServer;

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -10,9 +10,9 @@ container.provide("config", require("../config.json"));
 
 // Our code, written in a way that it expects the container to be passed
 // into a registration function.
-require("./api-server")(container);
-require("./logger")(container);
-require("./web-server")(container);
+container.instance("apiServer", require("./api-server"));
+container.singleton("logger", require("./logger"));
+container.instance("webServer", require("./web-server"));
 
 // Node modules
 container.provide("http", require("http"));

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,6 +12,4 @@ class Logger {
     }
 };
 
-module.exports = (container) => {
-    container.singleton("logger", Logger);
-};
+module.exports = Logger;

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -91,6 +91,4 @@ class WebServer {
     }
 }
 
-module.exports = (container) => {
-    container.instance("webServer", WebServer);
-};
+module.exports = WebServer;


### PR DESCRIPTION
Libraries were exporting a function that required use of a DI system in order to create the objects.  This commit pulls the container-related code out of the libraries, making them more usable to a wider audience.  All of the container-specific code is now in dependencies.js and whatever uses dependencies.js (like bin/server.js).