### PR TITLE
Avoid a full screen of error messages from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Public and free software API to tokenize or encrypt data.",
     "main": "lib/opentoken.js",
     "scripts": {
-        "start": "node bin/server.js",
+        "start": "node bin/server.js || true",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {


### PR DESCRIPTION
When the server runs and doesn't properly parse, such as during development, we do not want the errors to show up on our screen.  Can not set a property nor do something special to avoid this.  See npm/npm#6124 for more information.