### PR TITLE
Pretty printing and enabling the node environment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,29 @@
 {
     "parserOptions": {
         "ecmaVersion": 6
-     },
+    },
+    "env": {
+        "node": true
+    },
     "extends": "eslint:recommended",
     "rules": {
-        "indent": ["error", 4],
-        "quotes": ["error", "double"],
-        "linebreak-style": ["error", "unix"],
-        "no-trailing-spaces": [2, { "skipBlankLines": false }]
+        "indent": [
+            "error",
+            4
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-trailing-spaces": [
+            2,
+            {
+                "skipBlankLines": false
+            }
+        ]
     }
 }


### PR DESCRIPTION
Pretty printing is pretty obvious.

The environment change lets us use "require" and "module" without any fussing.  Cloud9 may not require it, but local installs of eslint may (mine does).