### PR TITLE
Adding a logger.console method for going to screen

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,4 @@
-/* global console */
+/* eslint no-console:true */
 
 "use strict";
 
@@ -6,6 +6,19 @@ class Logger {
     constructor(config) {
         this.config = config;
     }
+
+    /**
+     * Displays a message to the console only.
+     *
+     * @param {*} ...data All parameters are sent to console.log.
+     */
+    console() {
+        var args;
+
+        args = [].slice.call(arguments);
+        console.log.apply(console, args);
+    }
+
 
     /**
      * Logs debug statements to stderr only if


### PR DESCRIPTION
This is for making sure things do not go to a log file but are instead sent to the screen only.