### PR TITLE
Adding tests and fixing a Buffer-related bug

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -27,7 +27,7 @@ function base64Decode(data) {
         return (new Buffer(data, "base64")).toString("binary");
     }
 
-    return new Buffer(data, "base64");
+    return new Buffer(data.toString("binary"), "base64");
 }
 
 module.exports = {

--- a/spec/base64.spec.js
+++ b/spec/base64.spec.js
@@ -1,0 +1,63 @@
+"use strict";
+
+describe("base64", () => {
+    var base64;
+
+    beforeEach(() => {
+        base64 = require("../lib/base64");
+    });
+    [
+        {
+            decoded: "",
+            encoded: "",
+            name: "empty string"
+        },
+        {
+            decoded: "\x00",
+            encoded: "AA==",
+            name: "one null"
+        },
+        {
+            decoded: "\x00\x00",
+            encoded: "AAA=",
+            name: "two nulls"
+        },
+        {
+            decoded: "\x00\x00\x00",
+            encoded: "AAAA",
+            name: "three nulls"
+        },
+        {
+            decoded: "\xDE\xAD\xBE\xEF",
+            encoded: "3q2+7w==",
+            name: "DEAD BEEF"
+        }
+    ].forEach((scenario) => {
+        it("string encodes " + scenario.name, () => {
+            var result;
+
+            result = base64.encode(scenario.decoded);
+            expect(result).toEqual(scenario.encoded);
+        });
+        it("buffer encodes " + scenario.name, () => {
+            var result;
+
+            result = base64.encode(new Buffer(scenario.decoded, "binary"));
+            expect(result).toEqual(jasmine.any(Buffer));
+            expect(result.toString("binary")).toEqual(scenario.encoded);
+        });
+        it("string decodes " + scenario.name, () => {
+            var result;
+
+            result = base64.decode(scenario.encoded);
+            expect(result).toEqual(scenario.decoded);
+        });
+        it("buffer decodes " + scenario.name, () => {
+            var result;
+
+            result = base64.decode(new Buffer(scenario.encoded, "binary"));
+            expect(result).toEqual(jasmine.any(Buffer));
+            expect(result.toString("binary")).toEqual(scenario.decoded);
+        });
+    });
+});


### PR DESCRIPTION
When you take a buffer and construct a new buffer from it, Node seems to
copy the data over verbatim without converting the encoding.  To make
the Base64 data appear as binary again we first must convert the
incoming buffer to a string and then convert the string back to a Buffer
object with "base64" encoding.