### PR TITLE
Switching serialization to use OtDate

### DIFF
--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -25,7 +25,7 @@
  * Configuration options for serialization of data.
  *
  * @typedef {Object} serializer~options
- * @property {Date} expires Expiration date, used in serialize()
+ * @property {OtDate} expires Expiration date, used in serialize()
  */
 
 
@@ -36,7 +36,7 @@
  * @param {Object} zlib
  * @return {Object} serialization object
  */
-module.exports = function (promise, zlib) {
+module.exports = function (otDate, promise, zlib) {
     /**
      * Changes a serialized record back into the original data.  If the
      * data is expired, the data will NOT be returned.
@@ -118,17 +118,14 @@ module.exports = function (promise, zlib) {
      */
     function deserializeAsync01(record, offset) {
         return promise.try(() => {
-            var expires, expiresTime;
+            var expires;
 
-            expiresTime = record.readUInt32LE(offset);
-            expires = new Date();
-            expires.setTime(expiresTime * 1000);
+            expires = otDate.fromBuffer(record, offset);
+            offset += 4;
 
-            if (expires < new Date()) {
+            if (expires.isBefore(otDate.now())) {
                 throw new Error("Expired");
             }
-
-            offset += 4;
 
             return deserializeAsync00(record, offset);
         });
@@ -195,7 +192,7 @@ module.exports = function (promise, zlib) {
      * @return {Promise.<Buffer>} compressed, chunked contents, binary
      */
     function serializeAsync(data, options) {
-        var serializedBuffers, expiresTime;
+        var serializedBuffers;
 
         if (typeof data === "string") {
             data = new Buffer(data, "binary");
@@ -209,10 +206,7 @@ module.exports = function (promise, zlib) {
         // If there is an expiration date
         if (options && options.expires) {
             serializedBuffers[0][0] = 1;  // Version 1
-            expiresTime = options.expires.getTime();
-            expiresTime = Math.floor(expiresTime / 1000);
-            serializedBuffers.push(new Buffer(4));
-            serializedBuffers[1].writeUInt32LE(expiresTime, 0);
+            serializedBuffers.push(options.expires.toBuffer());
         }
 
         return zlib.deflateRawAsync(data).then((compressed) => {

--- a/spec/mock/ot-date-mock.js
+++ b/spec/mock/ot-date-mock.js
@@ -71,4 +71,4 @@ module.exports = {
     now: () => {
         return new OtDateMock(new Date());
     }
-}
+};

--- a/spec/mock/ot-date-mock.js
+++ b/spec/mock/ot-date-mock.js
@@ -1,0 +1,74 @@
+"use strict";
+
+function OtDateMock(d) {
+    this.date = d;
+
+    /**
+     * Determines if one OtDateMock is before another.
+     *
+     * Does not quite conform to OtDateMock parameters.
+     *
+     * @param {OtDateMock} other
+     * @return {boolean}
+     */
+    this.isBefore = jasmine.createSpy("isBefore").andCallFake((other) => {
+        return this.date < other.date;
+    });
+
+
+    /**
+     * Converts a date to a Buffer that's 4 bytes long
+     *
+     * @param {Buffer} [dest] If not specified, makes a new Buffer
+     * @param {number} [offset] Starting position in the buffer
+     * @return {Buffer}
+     */
+    this.toBuffer = jasmine.createSpy("toBuffer").andCallFake((dest, offset) => {
+        if (! dest) {
+            dest = new Buffer(4);
+            offset = 0;
+        }
+
+        dest.writeUInt32LE(Math.floor(this.date.getTime() / 1000), offset);
+
+        return dest;
+    });
+}
+
+module.exports = {
+    /**
+     * Convert a buffer to an OtDateMock
+     *
+     * @param {Buffer} buff
+     * @param {number} [offset]
+     * @return {OtDateMock}
+     */
+    fromBuffer: (buff, offset) => {
+        var d, t;
+
+        d = new Date();
+        t = buff.readUInt32LE(offset);
+        d.setTime(t * 1000);
+
+        return new OtDateMock(d);
+    },
+
+    /**
+     * Creates an OtDateMock from a string
+     *
+     * @param {string} str
+     * @return {OtDateMock}
+     */
+    fromString: (str) => {
+        return new OtDateMock(new Date(str));
+    },
+
+    /**
+     * Creates an OtDateMock from the current time
+     *
+     * @return {OtDateMock}
+     */
+    now: () => {
+        return new OtDateMock(new Date());
+    }
+}

--- a/spec/serialization.spec.js
+++ b/spec/serialization.spec.js
@@ -1,14 +1,15 @@
 "use strict";
 
 describe("serialization", () => {
-    var serialization;
+    var otDateMock, serialization;
 
     beforeEach(() => {
         var promiseMock, zlib;
 
+        otDateMock = require("./mock/ot-date-mock");
         promiseMock = require("./mock/promise-mock");
         zlib = require("zlib");
-        serialization = require("../lib/serialization")(promiseMock, zlib);
+        serialization = require("../lib/serialization")(otDateMock, promiseMock, zlib);
     });
     it("serializes a buffer", (done) => {
         // The rest of the tests use strings for ease
@@ -50,14 +51,14 @@ describe("serialization", () => {
     [
         {
             deserializes: true,
-            expires: new Date("2100-01-01T00:00:00Z"),
+            expiresStr: "2100-01-01T00:00:00Z",
             hex: "01005786f46306000000333432360100",
             name: "future date",
             plain: "1234"
         },
         {
             deserializes: false,
-            expires: new Date("2000-01-01T00:00:00Z"),
+            expiresStr: "2000-01-01T00:00:00Z",
             hex: "0180436d386306000000333432360100",
             name: "past date",
             plain: "1234"
@@ -65,7 +66,7 @@ describe("serialization", () => {
     ].forEach((scenario) => {
         it("serializes (version 1): " + scenario.name, (done) => {
             serialization.serializeAsync(scenario.plain, {
-                expires: scenario.expires
+                expires: otDateMock.fromString(scenario.expiresStr)
             }).then((result) => {
                 expect(result.toString("hex")).toEqual(scenario.hex);
             }).then(done, done);


### PR DESCRIPTION
Needed to also create an OtDateMock for simplicity.  Useful for
injecting into other places without worrying about its dependencies,
though it's not nearly as robust as the real OtDate.