### PR TITLE
Export only factories

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var apiServer, config, container, logger;
+var ApiServer, config, container, logger;
 
 container = require("../lib/dependencies");
 
@@ -19,5 +19,5 @@ if (process.env.DEBUG) {
     config.debug = true;
 }
 
-apiServer = container.resolve("apiServer");
-apiServer.startServerAsync();
+ApiServer = container.resolve("apiServer");
+(new ApiServer()).startServerAsync();

--- a/lib/api-server.js
+++ b/lib/api-server.js
@@ -1,24 +1,25 @@
 "use strict";
 
-class ApiServer {
-    constructor(config, webServer) {
-        this.webServer = webServer;
-        this.webServer.configure(config.server);
-        this.webServer.addRoute("get", "/", (req, res, next) => {
-            res.setHeader("content-type", "text/plain");
-            res.send("API running " + (new Date()) + "\n");
-            next();
-        });
+module.exports = (config, WebServer) => {
+    class ApiServer {
+        constructor() {
+            this.webServer = new WebServer(config.server);
+            this.webServer.addRoute("get", "/", (req, res, next) => {
+                res.setHeader("content-type", "text/plain");
+                res.send("API running " + (new Date()) + "\n");
+                next();
+            });
+        }
+
+        /**
+         * Starts the server
+         *
+         * @return {Promise}
+         */
+        startServerAsync() {
+            return this.webServer.startServerAsync();
+        }
     }
 
-    /**
-     * Starts the server
-     *
-     * @return {Promise}
-     */
-    startServerAsync() {
-        return this.webServer.startServerAsync();
-    }
+    return ApiServer;
 }
-
-module.exports = ApiServer;

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -18,7 +18,7 @@ container.provide("config", require("../config.json"));
 container.register("ApiServer", require("./api-server"));
 container.register("base64", require("./base64"));
 container.register("ciphersAndHashes", require("./ciphers-and-hashes"));
-container.singleton("logger", require("./logger"));
+container.register("logger", require("./logger"));
 container.instance("middlewareProfiler", require("./middleware-profiler"));
 container.register("otDate", require("./ot-date"));
 container.register("promise", require("./promise"));

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -25,7 +25,7 @@ container.register("promise", require("./promise"));
 container.register("random", require("./random"));
 container.register("restMiddleware", require("./rest-middleware"));
 container.register("serialization", require("./serialization"));
-container.instance("storage", require("./storage/s3"));
+container.register("Storage", require("./storage/s3"));
 container.register("WebServer", require("./web-server"));
 
 // Node modules and builtins -- all use `.provide()`

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -26,7 +26,7 @@ container.register("random", require("./random"));
 container.register("restMiddleware", require("./rest-middleware"));
 container.register("serialization", require("./serialization"));
 container.instance("storage", require("./storage/s3"));
-container.instance("webServer", require("./web-server"));
+container.register("WebServer", require("./web-server"));
 
 // Node modules and builtins -- all use `.provide()`
 container.provide("fs", require("fs"));

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -15,7 +15,7 @@ container.provide("config", require("../config.json"));
 // `.provide()` = Uses a value directly, no injection
 // `.instance()` = Returns a new instance for everywhere it is injected
 // `.singleton()` = Injects the same instance to all dependencies
-container.instance("apiServer", require("./api-server"));
+container.register("ApiServer", require("./api-server"));
 container.register("base64", require("./base64"));
 container.register("ciphersAndHashes", require("./ciphers-and-hashes"));
 container.singleton("logger", require("./logger"));

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -19,7 +19,7 @@ container.register("ApiServer", require("./api-server"));
 container.register("base64", require("./base64"));
 container.register("ciphersAndHashes", require("./ciphers-and-hashes"));
 container.register("logger", require("./logger"));
-container.instance("middlewareProfiler", require("./middleware-profiler"));
+container.register("MiddlewareProfiler", require("./middleware-profiler"));
 container.register("otDate", require("./ot-date"));
 container.register("promise", require("./promise"));
 container.register("random", require("./random"));

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,66 +2,62 @@
 
 "use strict";
 
-class Logger {
-    constructor(config) {
-        this.config = config;
-    }
+module.exports = (config) => {
+    return {
+        /**
+         * Displays a message to the console only.
+         *
+         * @param {*} ...data All parameters are sent to console.log.
+         */
+        console: function (x) {
+            var args;
 
-    /**
-     * Displays a message to the console only.
-     *
-     * @param {*} ...data All parameters are sent to console.log.
-     */
-    console() {
-        var args;
-
-        args = [].slice.call(arguments);
-        console.log.apply(console, args);
-    }
+            args = [].slice.call(arguments);
+            console.log.apply(console, args);
+        },
 
 
-    /**
-     * Logs debug statements to stderr only if
-     * debug has been turned on in environment variables
-     * or config.
-     *
-     * @param {string} text
-     */
-    debug(text) {
-        if (this.config.debug) {
-            console.error("DEBUG: " + text);
+        /**
+         * Logs debug statements to stderr only if
+         * debug has been turned on in environment variables
+         * or config.
+         *
+         * @param {string} text
+         */
+        debug: (text) => {
+            if (config.debug) {
+                console.error("DEBUG: " + text);
+            }
+        },
+
+
+        /**
+         * Logs errors to stderr
+         *
+         * @param {string} text
+         */
+        error: (text) => {
+            console.error("ERROR: " + text);
+        },
+
+
+        /**
+         * Logs info statements to stdout.
+         *
+         * @param {string} text
+         */
+        info: (text) => {
+            console.log(text);
+        },
+
+
+        /**
+         * Logs warn statments to stderr.
+         *
+         * @param {string} text
+         */
+        warn: (text) => {
+            console.error("WARN: " + text);
         }
-    }
-
-
-    /**
-     * Logs errors to stderr
-     *
-     * @param {string} text
-     */
-    error(text) {
-        console.error("ERROR: " + text);
-    }
-
-
-    /**
-     * Logs info statements to stdout.
-     *
-     * @param {string} text
-     */
-    info(text) {
-        console.log(text);
-    }
-
-
-    /**
-     * Logs warn statments to stderr.
-     *
-     * @param {string} text
-     */
-    warn(text) {
-        console.error("WARN: " + text);
-    }
+    };
 };
-
-module.exports = Logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,7 +9,7 @@ module.exports = (config) => {
          *
          * @param {*} ...data All parameters are sent to console.log.
          */
-        console: function (x) {
+        console: function () {
             var args;
 
             args = [].slice.call(arguments);

--- a/lib/middleware-profiler.js
+++ b/lib/middleware-profiler.js
@@ -1,139 +1,140 @@
 "use strict";
 
-/**
- * Monkey patches a server to enable profiling of middleware.  Does not
- * profile middleware that was already added to the server.
- *
- * It only tests middleware that executes successfully.  Anything that
- * throws will be lost.
- *
- * @return {Function}
- */
-class MiddlewareProfiler {
-    constructor(setIntervalFn) {
-        this.profiles = {};
-        this.setIntervalFn = setIntervalFn;
-    }
-
-
+module.exports = function (setIntervalFn) {
     /**
-     * Starts an interval that will display the results to a logger
+     * Monkey patches a server to enable profiling of middleware.  Does not
+     * profile middleware that was already added to the server.
      *
-     * @param {Function} callback
-     * @param {number} interval
+     * It only tests middleware that executes successfully.  Anything that
+     * throws will be lost.
+     *
+     * @return {Function}
      */
-    displayAtInterval(callback, interval) {
-        return this.setIntervalFn(() => {
-            callback(this.toString());
-        }, interval);
-    }
+    class MiddlewareProfiler {
+        constructor() {
+            this.profiles = {};
+        }
 
-
-    /**
-     * Returns the profile information.
-     *
-     * Note:  This structure's format is not fixed and may change in the
-     * future.
-     *
-     * @return {Object}
-     */
-    getProfiles() {
-        return this.profiles;
-    }
-
-
-    /**
-     * This does the actual patching of server.use to wrap the middleware
-     * in a timing function.
-     *
-     * @param {Restify} server
-     * @param {Function}
-     */
-    profileServer(server) {
-        var original, profiles;
-
-        original = server.use;
-        profiles = this.profiles;  // Copy to access in next function
 
         /**
-         * This is the patched `use` method.  It's context is the server
-         * object, not middlewareProfiler.
+         * Starts an interval that will display the results to a logger
          *
-         * @param {String} [route]
-         * @param {Function} fn
-         * @return {*} Whatever the original `use()` returns.
+         * @param {Function} callback
+         * @param {number} interval
          */
-        server.use = function (route, fn) {
-            var args, cumulative, logName;
+        displayAtInterval(callback, interval) {
+            return setIntervalFn(() => {
+                callback(this.toString());
+            }, interval);
+        }
 
-            function addElapsed(startTime, endTime) {
-                var elapsed;
 
-                elapsed = (endTime[0] - startTime[0]) + (endTime[1] - startTime[1]) / 1000000000;
-                cumulative.elapsed += elapsed;
-                cumulative.hits += 1;
+        /**
+         * Returns the profile information.
+         *
+         * Note:  This structure's format is not fixed and may change in the
+         * future.
+         *
+         * @return {Object}
+         */
+        getProfiles() {
+            return this.profiles;
+        }
+
+
+        /**
+         * This does the actual patching of server.use to wrap the middleware
+         * in a timing function.
+         *
+         * @param {Restify} server
+         * @param {Function}
+         */
+        profileServer(server) {
+            var original, profiles;
+
+            original = server.use;
+            profiles = this.profiles;  // Copy to access in next function
+
+            /**
+             * This is the patched `use` method.  It's context is the server
+             * object, not middlewareProfiler.
+             *
+             * @param {String} [route]
+             * @param {Function} fn
+             * @return {*} Whatever the original `use()` returns.
+             */
+            server.use = function (route, fn) {
+                var args, cumulative, logName;
+
+                function addElapsed(startTime, endTime) {
+                    var elapsed;
+
+                    elapsed = (endTime[0] - startTime[0]) + (endTime[1] - startTime[1]) / 1000000000;
+                    cumulative.elapsed += elapsed;
+                    cumulative.hits += 1;
+                }
+
+                function finished(req, res, next) {
+                    var startTime;
+
+                    startTime = process.hrtime();
+                    return fn.call(this, req, res, function (val) {
+                        addElapsed(startTime, process.hrtime());
+                        return next(val);
+                    });
+                }
+
+                if (typeof route === "function") {
+                    // "route" is really a function
+                    fn = route;
+                    route = null;
+                    args = [
+                        finished
+                    ];
+                } else {
+                    args = [
+                        route,
+                        finished
+                    ];
+                }
+
+                logName = fn.name.toString();
+
+                while (profiles[logName]) {
+                    logName += "_";
+                }
+
+                profiles[logName] = cumulative = {
+                    hits: 0,
+                    elapsed: 0
+                };
+
+                return original.apply(this, args);
             }
+        }
 
-            function finished(req, res, next) {
-                var startTime;
 
-                startTime = process.hrtime();
-                return fn.call(this, req, res, function (val) {
-                    addElapsed(startTime, process.hrtime());
-                    return next(val);
-                });
-            }
+        /**
+         * Converts stats to a textual representation
+         *
+         * @return {String}
+         */
+        toString() {
+            var lines;
 
-            if (typeof route === "function") {
-                // "route" is really a function
-                fn = route;
-                route = null;
-                args = [
-                    finished
-                ];
-            } else {
-                args = [
-                    route,
-                    finished
-                ];
-            }
+            lines = [];
+            Object.keys(this.profiles).forEach((name) => {
+                lines.push([
+                    name,
+                    this.profiles[name].hits + " hits",
+                    Math.round(this.profiles[name].elapsed * 1000) + " ms",
+                    Math.round(1000 * this.profiles[name].elapsed / this.profiles[name].hits) + " avg"
+                ].join(", "));
+            });
 
-            logName = fn.name.toString();
-
-            while (profiles[logName]) {
-                logName += "_";
-            }
-
-            profiles[logName] = cumulative = {
-                hits: 0,
-                elapsed: 0
-            };
-
-            return original.apply(this, args);
+            return lines.join("\n");
         }
     }
 
-
-    /**
-     * Converts stats to a textual representation
-     *
-     * @return {String}
-     */
-    toString() {
-        var lines;
-
-        lines = [];
-        Object.keys(this.profiles).forEach((name) => {
-            lines.push([
-                name,
-                this.profiles[name].hits + " hits",
-                Math.round(this.profiles[name].elapsed * 1000) + " ms",
-                Math.round(1000 * this.profiles[name].elapsed / this.profiles[name].hits) + " avg"
-            ].join(", "));
-        });
-
-        return lines.join("\n");
-    }
+    return MiddlewareProfiler;
 }
-
-module.exports = MiddlewareProfiler;

--- a/lib/ot-date.js
+++ b/lib/ot-date.js
@@ -68,7 +68,7 @@ module.exports = function (moment) {
          *    {"days": 1, "hours": 5, "seconds": 3}
          *
          * @param {OtDate~spec} spec
-         * @return {OtDate}
+         * @return {this}
          */
         plus(spec) {
             this.moment.add(spec);
@@ -119,7 +119,7 @@ module.exports = function (moment) {
         toString() {
             return this.moment.toISOString();
         }
-    };
+    }
 
 
     /**

--- a/lib/rest-middleware.js
+++ b/lib/rest-middleware.js
@@ -1,4 +1,4 @@
-module.exports = function restMiddleware(helmet, logger, restifyLinks) {
+module.exports = function (helmet, logger, restifyLinks) {
     /**
      * Chains middleware from Helmet and other sources.
      *

--- a/lib/rest-middleware.js
+++ b/lib/rest-middleware.js
@@ -1,11 +1,11 @@
-function restMiddleware(helmet, logger, restifyLinks) {
+module.exports = function restMiddleware(helmet, logger, restifyLinks) {
     /**
      * Chains middleware from Helmet and other sources.
      *
      * @param {Object} config
      * @return {Function} useMiddleware
      */
-    return function(config, server) {
+    return (config, server) => {
         /**
          * Sets up the self discovery link.
          *
@@ -50,6 +50,4 @@ function restMiddleware(helmet, logger, restifyLinks) {
 
         return useMiddleware();
     };
-}
-
-module.exports = restMiddleware;
+};

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -13,7 +13,7 @@ module.exports = function (awsSdk, promise) {
          * Configures options for AWS.
          *
          * @param {Object} config
-         * @return {Object} this
+         * @return {S3} this
          */
         configure(config) {
             if (!config || typeof config !== "object") {

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -1,142 +1,142 @@
 "use strict";
 
-class S3 {
-    /**
-     * @param {Object} awsSdk
-     * @param {Object} promise
-     */
-    constructor(awsSdk, promise) {
-        this.aws = awsSdk;
-        this.config = {};
-        this.configure({});
-        this.promise = promise;
-        this.awsS3 = null;
-    }
-
-
-    /**
-     * Configures options for AWS.
-     *
-     * @param {Object} config
-     * @return {Object} this
-     */
-    configure(config) {
-        this.aws.config.region = config.region || "us-east-1";
-        this.config.bucket = config.bucket || null;
-
-        return this;
-    }
-
-
-    /**
-     * Deletes a single file from configured bucket.
-     *
-     * @param {string} filename
-     * @return {Promise.<*>} promise
-     */
-    delAsync(filename) {
-        return this.transit().deleteObjectAsync({
-            Key: filename
-        });
-    }
-
-
-    /**
-     * Gets a file from S3 from the configured bucket.
-     *
-     * @param {string} filename
-     * @return {Promise.<Buffer>} indicates success/error of operation
-     */
-    getAsync(filename) {
-        return this.transit().getObjectAsync({
-            Key: filename
-        }).then((response) => {
-            return response.Body;
-        });
-    }
-
-
-    /**
-     * Gets a list of files and "directories" from S3.
-     *
-     * S3 stores the data in an "object" structure which
-     * will create psuedo directories.
-     * By passing in a prefix with slash will allow one to
-     * navigate the objects as if they are directories.
-     *
-     *    Object in S3
-     *    accounts/person1/information
-     *
-     * Passing in the prefix accounts/person1
-     * would send back the entire object accounts/person1/information
-     * as your data.
-     *
-     * @param {string} prefix
-     * @return {Promise.<*>} indicates success/error of operation
-     */
-    listAsync(prefix) {
-        return this.transit().listObjectsAsync({
-            Prefix: prefix || null
-        });
-    }
-
-
-    /**
-     * Uploads a file to the S3 bucket configured.
-     * We always want the data to be a buffer type
-     * in binary.
-     *
-     * Passing in contents with slashes will make the object
-     * on S3 look and behave like a directory.
-     *
-     * @param {string} filename
-     * @param {(Buffer|string)} contents
-     * @param {Object} options
-     * @return {Promise.<*>} indicates success/error of operation
-     */
-    putAsync(filename, contents, options) {
-        var params;
-
-        if (typeof contents === "string") {
-            contents = new Buffer(contents, "binary");
+module.exports = function (awsSdk, promise) {
+    class S3 {
+        constructor(config) {
+            this.config = {};
+            this.configure(config);
+            this.awsS3 = null;
         }
 
-        params = {
-            Body: contents,
-            ContentType: "application/octet-stream",
-            Key: filename,
-            ServerSideEncryption: "AES256"
-        };
 
-        if (options && typeof options === "object") {
-            params.ContentType = options.contentType || params.ContentType;
-            params.Expires = options.expires || null;
+        /**
+         * Configures options for AWS.
+         *
+         * @param {Object} config
+         * @return {Object} this
+         */
+        configure(config) {
+            if (!config || typeof config !== "object") {
+                config = {};
+            }
+
+            awsSdk.config.region = config.region || "us-east-1";
+            this.config.bucket = config.bucket || null;
+
+            return this;
         }
 
-        return this.transit().putObjectAsync(params);
-    }
 
-
-    /**
-     * Creates the S3 bucket we need for subsequent calls.  Not intended
-     * for general consumption; do not use this from outside the class
-     * unless it is required for testing.
-     *
-     * @return {Object} awsS3
-     */
-    transit() {
-        if (! this.awsS3) {
-            this.awsS3 = new this.aws.S3({
-                params: {
-                    Bucket: this.config.bucket
-                }
+        /**
+         * Deletes a single file from configured bucket.
+         *
+         * @param {string} filename
+         * @return {Promise.<*>} promise
+         */
+        delAsync(filename) {
+            return this.transit().deleteObjectAsync({
+                Key: filename
             });
-
-            this.awsS3 = this.promise.promisifyAll(this.awsS3);
         }
 
-        return this.awsS3;
-    }
-}
 
-module.exports = S3;
+        /**
+         * Gets a file from S3 from the configured bucket.
+         *
+         * @param {string} filename
+         * @return {Promise.<Buffer>} indicates success/error of operation
+         */
+        getAsync(filename) {
+            return this.transit().getObjectAsync({
+                Key: filename
+            }).then((response) => {
+                return response.Body;
+            });
+        }
+
+
+        /**
+         * Gets a list of files and "directories" from S3.
+         *
+         * S3 stores the data in an "object" structure which
+         * will create psuedo directories.
+         * By passing in a prefix with slash will allow one to
+         * navigate the objects as if they are directories.
+         *
+         *    Object in S3
+         *    accounts/person1/information
+         *
+         * Passing in the prefix accounts/person1
+         * would send back the entire object accounts/person1/information
+         * as your data.
+         *
+         * @param {string} prefix
+         * @return {Promise.<*>} indicates success/error of operation
+         */
+        listAsync(prefix) {
+            return this.transit().listObjectsAsync({
+                Prefix: prefix || null
+            });
+        }
+
+
+        /**
+         * Uploads a file to the S3 bucket configured.
+         * We always want the data to be a buffer type
+         * in binary.
+         *
+         * Passing in contents with slashes will make the object
+         * on S3 look and behave like a directory.
+         *
+         * @param {string} filename
+         * @param {(Buffer|string)} contents
+         * @param {Object} options
+         * @return {Promise.<*>} indicates success/error of operation
+         */
+        putAsync(filename, contents, options) {
+            var params;
+
+            if (typeof contents === "string") {
+                contents = new Buffer(contents, "binary");
+            }
+
+            params = {
+                Body: contents,
+                ContentType: "application/octet-stream",
+                Key: filename,
+                ServerSideEncryption: "AES256"
+            };
+
+            if (options && typeof options === "object") {
+                params.ContentType = options.contentType || params.ContentType;
+                params.Expires = options.expires || null;
+            }
+
+            return this.transit().putObjectAsync(params);
+        }
+
+
+        /**
+         * Creates the S3 bucket we need for subsequent calls.  Not intended
+         * for general consumption; do not use this from outside the class
+         * unless it is required for testing.
+         *
+         * @return {Object} awsS3
+         */
+        transit() {
+            if (! this.awsS3) {
+                this.awsS3 = new awsSdk.S3({
+                    params: {
+                        Bucket: this.config.bucket
+                    }
+                });
+
+                this.awsS3 = promise.promisifyAll(this.awsS3);
+            }
+
+            return this.awsS3;
+        }
+    }
+
+    return S3;
+};

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -132,7 +132,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddlewa
          * Sets configuration options.
          *
          * @param {Object} config
-         * @return this
+         * @return {this}
          */
         configure(config) {
             if (!config || typeof config !== "object") {
@@ -242,7 +242,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddlewa
          * Will start a https server if there is information in the
          * config section for key locations.
          *
-         * @return {Promise}
+         * @return {Promise.<*>}
          */
         startServerAsync() {
             var contracts, promiseResult;

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -6,16 +6,16 @@ class WebServer {
      *
      * @param {Object} fs
      * @param {Object} logger
-     * @param {Function} middlewareProfiler
+     * @param {Function} MiddlewareProfiler
      * @param {Object} promise
      * @param {Object} restify
      * @param {Function} restMiddleware
      */
-    constructor(fs, logger, middlewareProfiler, promise, restify, restMiddleware) {
+    constructor(fs, logger, MiddlewareProfiler, promise, restify, restMiddleware) {
         this.configure({});// Sets this.config, this.restifyConfig
         this.fs = promise.promisifyAll(fs);
         this.logger = logger;
-        this.middlewareProfiler = middlewareProfiler;
+        this.MiddlewareProfiler = MiddlewareProfiler;
         this.promise = promise;
         this.restify = restify;
         this.restMiddleware = restMiddleware;
@@ -221,9 +221,12 @@ class WebServer {
      */
     profileMiddleware() {
         return (server) => {
+            var profiler;
+
             this.logger.debug("Profiling middleware");
-            this.middlewareProfiler.profileServer(server);
-            this.middlewareProfiler.displayAtInterval(10000, this.logger.info.bind(this.logger));
+            profiler = new this.MiddlewareProfiler();
+            profiler.profileServer(server);
+            profiler.displayAtInterval(10000, this.logger.info.bind(this.logger));
 
             return server;
         };

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -1,281 +1,271 @@
 "use strict";
 
-class WebServer {
-    /**
-     * This is mostly used for dependency injection.
-     *
-     * @param {Object} fs
-     * @param {Object} logger
-     * @param {Function} MiddlewareProfiler
-     * @param {Object} promise
-     * @param {Object} restify
-     * @param {Function} restMiddleware
-     */
-    constructor(fs, logger, MiddlewareProfiler, promise, restify, restMiddleware) {
-        this.configure({});// Sets this.config, this.restifyConfig
-        this.fs = promise.promisifyAll(fs);
-        this.logger = logger;
-        this.MiddlewareProfiler = MiddlewareProfiler;
-        this.promise = promise;
-        this.restify = restify;
-        this.restMiddleware = restMiddleware;
-        this.serverContracts = [];
-    }
+module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddleware) => {
+    class WebServer {
+        constructor(config) {
+            this.configure(config);  // Sets this.config, this.restifyConfig
+            this.serverContracts = [];
+        }
 
 
-    /**
-     * Adds a contract so when the server is created then additional
-     * functionality is added to the server, such as routes and middleware.
-     *
-     * @private
-     * @param {Function} fn
-     */
-    addContract(fn) {
-        this.serverContracts.push(fn);
-    }
+        /**
+         * Adds a contract so when the server is created then additional
+         * functionality is added to the server, such as routes and middleware.
+         *
+         * @private
+         * @param {Function} fn
+         */
+        addContract(fn) {
+            this.serverContracts.push(fn);
+        }
 
 
-    /**
-     * Sets up middleware functionality for the web server
-     *
-     * @param {(string|Function)} a
-     * @param {Function} b
-     * @return {this}
-     */
-    addMiddleware(a, b) {
-        if (arguments.length > 1) {
+        /**
+         * Sets up middleware functionality for the web server
+         *
+         * @param {(string|Function)} a
+         * @param {Function} b
+         * @return {this}
+         */
+        addMiddleware(a, b) {
+            if (arguments.length > 1) {
+                this.addContract((server) => {
+                    logger.debug("Adding middleware for route: " + a);
+                    server.use(a, b);  // path and callback
+
+                    return server;
+                });
+            } else {
+                this.addContract((server) => {
+                    logger.debug("Adding middleware");
+                    server.use(a);  // a = callback
+
+                    return server;
+                });
+            }
+
+            return this;
+        }
+
+
+        /**
+         * This is used for setting up a verb to be called within the application
+         *
+         * @param {string} method
+         * @param {string} route
+         * @param {Function} callback
+         * @return {this}
+         */
+        addRoute(method, route, callback) {
+            method = method.toLowerCase();
+
+            if (method == "delete") {
+                method = "del";
+            }
+
             this.addContract((server) => {
-                this.logger.debug("Adding middleware for route: " + a);
-                server.use(a, b);  // path and callback
+                logger.debug("Adding route: " + method + " " + route);
+                server[method](route, callback);
 
                 return server;
             });
-        } else {
-            this.addContract((server) => {
-                this.logger.debug("Adding middleware");
-                server.use(a);  // a = callback
+
+            return this;
+        }
+
+
+        /**
+         * Creates the app if not already created.
+         *
+         * @private
+         * @return {Promise.<Restify>}
+         */
+        app() {
+            var promiseResult;
+
+            logger.debug("Creating server with config: " + JSON.stringify(this.config));
+
+            if (this.config.https) {
+                promiseResult = promise.all([
+                    fs.readFileAsync(this.config.certificateFile).then((contents) => {
+                        this.restifyConfig.certificate = contents;
+                    }),
+                    fs.readFileAsync(this.config.keyFile).then((contents) => {
+                        this.restifyConfig.key = contents;
+                    })
+                ]);
+            } else {
+                promiseResult = promise.resolve();
+            }
+
+            promiseResult = promiseResult.then(() => {
+                return restify.createServer(this.restifyConfig);
+            });
+
+            return promiseResult;
+        }
+
+
+        /**
+         * Attaches error handling to the server. This captures different error
+         * types, suppresses their output to console or to the client and then they
+         * get caught by the Uncaught Exception Handler.
+         *
+         * @private
+         * @return {Function}
+         */
+        attachErrorHandlers() {
+            return (server) => {
+                server.on("uncaughtException", (req, res, route, error) => {
+                    logger.error("Uncaught Exception: " + error.toString());
+                    logger.console("Uncaught Exception:", error);
+
+                    res.send(500);
+                });
 
                 return server;
-            });
+            };
         }
 
-        return this;
-    }
 
+        /**
+         * Sets configuration options.
+         *
+         * @param {Object} config
+         * @return this
+         */
+        configure(config) {
+            if (!config || typeof config !== "object") {
+                config = {};
+            }
 
-    /**
-     * This is used for setting up a verb to be called within the application
-     *
-     * @param {string} method
-     * @param {string} route
-     * @param {Function} callback
-     * @return {this}
-     */
-    addRoute(method, route, callback) {
-        method = method.toLowerCase();
+            // All values go in here and are converted to the right data types
+            this.config = {
+                baseUrl: config.baseUrl || "",
+                certificateFile: config.certificateFile,  // HTTPS CA Chain and certificate
+                keyFile: config.keyFile, // HTTPS private key
+                https: true,
+                name: config.name || "OpenToken API",  // For Server Name fields
+                port: +(config.port || 8080), // For listening
+                profileMiddleware: !!config.profileMiddleware,
+                proxyProtocol: config.proxyProtocol || false,  // boolean or object
+                spdy: config.spdy || null,  // Options for node-spdy
+                version: config.version || null  // For routes
+            };
+            config = null;  // For safety - don't use this object any longer
 
-        if (method == "delete") {
-            method = "del";
+            // Make sure our baseUrl does not end with a slash
+            if (this.config.baseUrl.substr(-1) === "/") {
+                this.config.baseUrl = this.config.baseUrl.substr(0, this.config.baseUrl.length - 1);
+            }
+
+            // Error checking HTTPS options
+            if (!this.config.certificateFile || !this.config.keyFile) {
+                this.config.certificateFile = null;
+                this.config.keyFile = null;
+                this.config.https = false;
+            }
+
+            // Select values are plucked into this one
+            this.restifyConfig = {
+                handleUncaughtExceptions: true, // Turning on uncaughtException handling
+                handleUpgrades: false,  // Intentionally do not upgrade the connection
+                httpsServerOptions: null,  // Could construct this object instead
+                name: this.config.name,
+                proxyProtocol: this.config.proxyProtocol,
+                spdy: this.config.spdy,
+                version: this.config.version
+            };
+
+            return this;
         }
 
-        this.addContract((server) => {
-            this.logger.debug("Adding route: " + method + " " + route);
-            server[method](route, callback);
 
-            return server;
-        });
+        /**
+         * Starts the server listening.  This is intentionally the last bit
+         * done to the server so that everything is initialized before we open
+         * the port and accept requests.
+         *
+         * @param {number} port
+         * @return {Function}
+         */
+        listen(port) {
+            return (server) => {
+                return promise.fromCallback((callback) => {
+                    server.listen(port, callback);
+                }).then(() => {
+                    logger.info("Server listening on port " + port);
 
-        return this;
-    }
-
-
-    /**
-     * Creates the app if not already created.
-     *
-     * @private
-     * @return {Promise.<Restify>}
-     */
-    app() {
-        var promise;
-
-        this.logger.debug("Creating server with config: " + JSON.stringify(this.config));
-
-        if (this.config.https) {
-            promise = this.promise.all([
-                this.fs.readFileAsync(this.config.certificateFile).then((contents) => {
-                    this.restifyConfig.certificate = contents;
-                }),
-                this.fs.readFileAsync(this.config.keyFile).then((contents) => {
-                    this.restifyConfig.key = contents;
-                })
-            ]);
-        } else {
-            promise = this.promise.resolve();
+                    return server;
+                });
+            };
         }
 
-        promise = promise.then(() => {
-            return this.restify.createServer(this.restifyConfig);
-        });
 
-        return promise;
-    }
+        /**
+         * Adds middleware to profile the middleware.
+         *
+         * @private
+         * @return {Function}
+         */
+        profileMiddleware() {
+            return (server) => {
+                var profiler;
 
-
-    /**
-     * Attaches error handling to the server. This captures different error
-     * types, suppresses their output to console or to the client and then they
-     * get caught by the Uncaught Exception Handler.
-     *
-     * @private
-     * @return {Function}
-     */
-    attachErrorHandlers() {
-        return (server) => {
-            server.on("uncaughtException", (req, res, route, error) => {
-                this.logger.error("Uncaught Exception: " + error.toString());
-                this.logger.console("Uncaught Exception:", error);
-
-                res.send(500);
-            });
-
-            return server;
-        };
-    }
-
-
-    /**
-     * Sets configuration options.
-     *
-     * @param {Object} config
-     * @return this
-     */
-    configure(config) {
-        // All values go in here and are converted to the right data types
-        this.config = {
-            baseUrl: config.baseUrl || "",
-            certificateFile: config.certificateFile,  // HTTPS CA Chain and certificate
-            keyFile: config.keyFile, // HTTPS private key
-            https: true,
-            name: config.name || "OpenToken API",  // For Server Name fields
-            port: +(config.port || 8080), // For listening
-            profileMiddleware: !!config.profileMiddleware,
-            proxyProtocol: config.proxyProtocol || false,  // boolean or object
-            spdy: config.spdy || null,  // Options for node-spdy
-            version: config.version || null  // For routes
-        };
-        config = null;  // For safety - don't use this object any longer
-
-        // Make sure our baseUrl does not end with a slash
-        if (this.config.baseUrl.substr(-1) === "/") {
-            this.config.baseUrl = this.config.baseUrl.substr(0, this.config.baseUrl.length - 1);
-        }
-
-        // Error checking HTTPS options
-        if (!this.config.certificateFile || !this.config.keyFile) {
-            this.config.certificateFile = null;
-            this.config.keyFile = null;
-            this.config.https = false;
-        }
-
-        // Select values are plucked into this one
-        this.restifyConfig = {
-            handleUncaughtExceptions: true, // Turning on uncaughtException handling
-            handleUpgrades: false,  // Intentionally do not upgrade the connection
-            httpsServerOptions: null,  // Could construct this object instead
-            name: this.config.name,
-            proxyProtocol: this.config.proxyProtocol,
-            spdy: this.config.spdy,
-            version: this.config.version
-        };
-
-        return this;
-    }
-
-
-    /**
-     * Starts the server listening.  This is intentionally the last bit
-     * done to the server so that everything is initialized before we open
-     * the port and accept requests.
-     *
-     * @param {number} port
-     * @return {Function}
-     */
-    listen(port) {
-        return (server) => {
-            return this.promise.fromCallback((callback) => {
-                server.listen(port, callback);
-            }).then(() => {
-                this.logger.info("Server listening on port " + port);
+                logger.debug("Profiling middleware");
+                profiler = new MiddlewareProfiler();
+                profiler.profileServer(server);
+                profiler.displayAtInterval(10000, logger.info.bind(logger));
 
                 return server;
-            });
-        };
-    }
-
-
-    /**
-     * Adds middleware to profile the middleware.
-     *
-     * @private
-     * @return {Function}
-     */
-    profileMiddleware() {
-        return (server) => {
-            var profiler;
-
-            this.logger.debug("Profiling middleware");
-            profiler = new this.MiddlewareProfiler();
-            profiler.profileServer(server);
-            profiler.displayAtInterval(10000, this.logger.info.bind(this.logger));
-
-            return server;
-        };
-    }
-
-
-    /**
-     * Includes standard REST middleware from the restMiddleware library
-     *
-     * @private
-     * @return {Function}
-     */
-    standardRestMiddleware() {
-        return (server) => {
-            this.restMiddleware(this.config, server);
-
-            return server;
-        };
-    }
-
-
-    /**
-     * Starts a web server using the config passed in.
-     * Will start a https server if there is information in the
-     * config section for key locations.
-     *
-     * @return {Promise}
-     */
-    startServerAsync() {
-        var contracts, promise;
-
-        this.logger.debug("Starting server");
-        contracts = [];
-
-        if (this.config.profileMiddleware) {
-            contracts.push(this.profileMiddleware());
+            };
         }
 
-        contracts.push(this.standardRestMiddleware());
-        contracts.push(this.attachErrorHandlers());
-        contracts = contracts.concat(this.serverContracts);
-        contracts.push(this.listen(this.config.port));
-        promise = this.app();
-        contracts.forEach((contract) => {
-            promise = promise.then(contract);
-        });
 
-        return promise;
+        /**
+         * Includes standard REST middleware from the restMiddleware library
+         *
+         * @private
+         * @return {Function}
+         */
+        standardRestMiddleware() {
+            return (server) => {
+                restMiddleware(this.config, server);
+
+                return server;
+            };
+        }
+
+
+        /**
+         * Starts a web server using the config passed in.
+         * Will start a https server if there is information in the
+         * config section for key locations.
+         *
+         * @return {Promise}
+         */
+        startServerAsync() {
+            var contracts, promiseResult;
+
+            logger.debug("Starting server");
+            contracts = [];
+
+            if (this.config.profileMiddleware) {
+                contracts.push(this.profileMiddleware());
+            }
+
+            contracts.push(this.standardRestMiddleware());
+            contracts.push(this.attachErrorHandlers());
+            contracts = contracts.concat(this.serverContracts);
+            contracts.push(this.listen(this.config.port));
+            promiseResult = this.app();
+            contracts.forEach((contract) => {
+                promiseResult = promiseResult.then(contract);
+            });
+
+            return promiseResult;
+        }
     }
-}
 
-module.exports = WebServer;
+    return WebServer;
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "aws-sdk": "^2.3.3",
         "bluebird": "^3.3.4",
-        "dizzy": "^1.0.2",
+        "dizzy": "^1.0.3",
         "findhit-proxywrap": "^0.3.11",
         "helmet": "^1.3.0",
         "moment": "^2.12.0",

--- a/spec/dependencies.spec.js
+++ b/spec/dependencies.spec.js
@@ -15,7 +15,7 @@ describe("dependencies", () => {
     it("resolve a dependency which has methods to run", () => {
         var webServer;
 
-        webServer = dependencies.resolve("webServer");
-        expect(webServer.startServerAsync).toEqual(jasmine.any(Function));
+        webServer = dependencies.resolve("WebServer");
+        expect(webServer).toEqual(jasmine.any(Function));
     });
 });

--- a/spec/logger.spec.js
+++ b/spec/logger.spec.js
@@ -1,49 +1,52 @@
 "use strict";
 
 describe("logger", () => {
-    var log, logger;
+    var loggerFactory;
 
     beforeEach(() => {
-        logger = require("../lib/logger");
-
+        loggerFactory = require("../lib/logger");
         spyOn(console, "log");
         spyOn(console, "error");
     });
 
     describe("constructor", () => {
+        var log;
+
         beforeEach(() => {
-            log = new logger({});
+            log = loggerFactory({});
         });
 
         it("prints to log from info", () => {
-            log.info("something");
-            expect(console.log).toHaveBeenCalledWith("something");
+            log.info("something1");
+            expect(console.log).toHaveBeenCalledWith("something1");
         });
 
         it("prints to error from error", () => {
-            log.error("something");
-            expect(console.error).toHaveBeenCalledWith("ERROR: something");
+            log.error("something3");
+            expect(console.error).toHaveBeenCalledWith("ERROR: something3");
         });
 
         it("prints to error from warn", () => {
-            log.warn("something");
-            expect(console.error).toHaveBeenCalledWith("WARN: something");
+            log.warn("something4");
+            expect(console.error).toHaveBeenCalledWith("WARN: something4");
         });
 
         it("prints to log from console", () => {
-            log.console("something");
-            expect(console.log).toHaveBeenCalledWith("something");
+            log.console("something2");
+            expect(console.log).toHaveBeenCalledWith("something2");
         });
 
         it("does not print to error from debug", () => {
-            log.debug("something");
-            expect(console.error).not.toHaveBeenCalledWith("something");
+            log.debug("something5");
+            expect(console.error).not.toHaveBeenCalledWith("something5");
         });
     });
 
     describe("constructor with debug set", () => {
+        var log;
+
         beforeEach(() => {
-            log = new logger({
+            log = loggerFactory({
                 debug: true
             });
         });

--- a/spec/middleware-profiler.spec.js
+++ b/spec/middleware-profiler.spec.js
@@ -6,9 +6,9 @@ describe("MiddlewareProfiler", () => {
     beforeEach(() => {
         var MiddlewareProfiler;
 
-        MiddlewareProfiler = require("../lib/middleware-profiler");
         setIntervalFn = jasmine.createSpy("setIntervalFn");
-        mp = new MiddlewareProfiler(setIntervalFn);
+        MiddlewareProfiler = require("../lib/middleware-profiler")(setIntervalFn);
+        mp = new MiddlewareProfiler();
     });
     it("exposes known public methods", () => {
         expect(mp.displayAtInterval).toEqual(jasmine.any(Function));

--- a/spec/mock/logger-mock.js
+++ b/spec/mock/logger-mock.js
@@ -1,17 +1,15 @@
 "use strict";
 
-class LoggerMock {
-    constructor() {
-        [
-            "console",
-            "debug",
-            "error",
-            "info",
-            "warn"
-        ].forEach((methodName) => {
-            this[methodName] = jasmine.createSpy("logger." + methodName);
-        });
-    }
-};
+var logger;
 
-module.exports = LoggerMock;
+logger = {};
+[
+    "console",
+    "debug",
+    "error",
+    "info",
+    "warn"
+].forEach((methodName) => {
+    logger[methodName] = jasmine.createSpy("logger." + methodName);
+});
+module.exports = logger;

--- a/spec/mock/web-server-mock.js
+++ b/spec/mock/web-server-mock.js
@@ -1,0 +1,25 @@
+/**
+ * Mock WebServer class
+ */
+
+"use strict";
+
+var promiseMock;
+
+promiseMock = require("./promise-mock");
+
+class WebServerMock {
+    constructor(config) {
+        this.config = config;
+
+        [
+            "addRoute",
+            "startServerAsync"
+        ].forEach((methodName) => {
+            this[methodName] = jasmine.createSpy(methodName);
+        });
+        this.startServerAsync.andReturn(promiseMock.resolve());
+    }
+}
+
+module.exports = WebServerMock;

--- a/spec/rest-middleware.spec.js
+++ b/spec/rest-middleware.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("restMiddleware", () => {
-    var helmetMock, logger, restMiddleware, serverMock, restifyLinks;
+    var helmetMock, restMiddleware, serverMock, restifyLinks;
 
     /**
      * Tests the common middleware set up when calling restMiddleware.
@@ -20,10 +20,10 @@ describe("restMiddleware", () => {
     }
 
     beforeEach(() => {
-        var LoggerMock, RestMiddleware;
+        var loggerMock, RestMiddleware;
 
         RestMiddleware = require("../lib/rest-middleware");
-        LoggerMock = require("./mock/logger-mock");
+        loggerMock = require("./mock/logger-mock");
         helmetMock = jasmine.createSpyObj("helmetMock", [
             "frameguard",
             "hidePoweredBy",
@@ -37,8 +37,7 @@ describe("restMiddleware", () => {
             "use"
         ]);
         restifyLinks = jasmine.createSpy();
-        logger = new LoggerMock();
-        restMiddleware = new RestMiddleware(helmetMock, logger, restifyLinks);
+        restMiddleware = new RestMiddleware(helmetMock, loggerMock, restifyLinks);
     });
     it("calls restMiddleware without https", () => {
         restMiddleware({

--- a/spec/storage/s3.spec.js
+++ b/spec/storage/s3.spec.js
@@ -4,7 +4,7 @@ describe("storage/s3", () => {
     var awsSdkMock, promiseMock, s3;
 
     beforeEach(() => {
-        var s3File;
+        var S3;
 
         class S3Fake {
             constructor(params) {
@@ -23,7 +23,6 @@ describe("storage/s3", () => {
             }
         }
 
-        s3File = require("../../lib/storage/s3");
         promiseMock = require("../mock/promise-mock");
         awsSdkMock = {
             S3: S3Fake,
@@ -31,14 +30,15 @@ describe("storage/s3", () => {
                 region: null
             }
         };
-        s3 = new s3File(awsSdkMock, promiseMock);
+        S3 = require("../../lib/storage/s3")(awsSdkMock, promiseMock);
+        s3 = new S3();
     });
     describe("configure()", () => {
         beforeEach(() => {
             awsSdkMock.S3 = jasmine.createSpy("s3Mock");
         });
         it("passes in configuration options for all", () => {
-            expect(s3.aws.config.region).toBe("us-east-1");
+            expect(awsSdkMock.config.region).toBe("us-east-1");
             s3.transit();
             expect(awsSdkMock.S3).toHaveBeenCalledWith({
                 params: {
@@ -51,7 +51,7 @@ describe("storage/s3", () => {
                 region: "us-west-1",
                 bucket: "test-bucket"
             });
-            expect(s3.aws.config.region).toBe("us-west-1");
+            expect(awsSdkMock.config.region).toBe("us-west-1");
             s3.transit();
             expect(awsSdkMock.S3).toHaveBeenCalledWith({
                 params: {

--- a/spec/web-server.spec.js
+++ b/spec/web-server.spec.js
@@ -1,10 +1,10 @@
 "use strict";
 
 describe("WebServer", () => {
-    var fs, logger, middlewareProfiler, promiseMock, restify, restifyServer, restMiddleware, webServer;
+    var fs, loggerMock, middlewareProfiler, promiseMock, restify, restifyServer, restMiddleware, webServer;
 
     beforeEach(() => {
-        var LoggerMock, WebServer;
+        var WebServer;
 
         // Set up a fake MiddlewareProfiler object
         class MiddlewareProfilerMock {
@@ -21,8 +21,7 @@ describe("WebServer", () => {
 
         middlewareProfiler = null;
         promiseMock = require("./mock/promise-mock");
-        LoggerMock = require("./mock/logger-mock");
-        WebServer = require("../lib/web-server");
+        loggerMock = require("./mock/logger-mock");
         fs = jasmine.createSpyObj("fs", [
             "readFileAsync"
         ]);
@@ -41,8 +40,8 @@ describe("WebServer", () => {
         ]);
         restify.createServer.andReturn(restifyServer);
         restMiddleware = jasmine.createSpy("restMiddleware");
-        logger = new LoggerMock();
-        webServer = new WebServer(fs, logger, MiddlewareProfilerMock, promiseMock, restify, restMiddleware);
+        WebServer = require("../lib/web-server")(fs, loggerMock, MiddlewareProfilerMock, promiseMock, restify, restMiddleware);
+        webServer = new WebServer();
     });
     it("exposes known public methods", () => {
         expect(webServer.addMiddleware).toEqual(jasmine.any(Function));
@@ -293,7 +292,7 @@ describe("WebServer", () => {
                 expect(args[1]).toEqual(jasmine.any(Function));
                 uncaughtCallback = args[1];
                 uncaughtCallback(req, res, route, {"error": true});
-                expect(logger.error).toHaveBeenCalled();
+                expect(loggerMock.error).toHaveBeenCalled();
                 expect(res.send).toHaveBeenCalledWith(500);
                 expect(res.write).not.toHaveBeenCalled();
             }).then(done, done);


### PR DESCRIPTION
This rewrites the libraries so they always export factories.  Those factories may export classes or plain objects.  When a class had no internal state, it was converted to a plain object.

This also caught a few problems with the testing that were invisible previously, such as places where we reached into the instance and checked internal properties instead of checking that the right things were performed on the dependencies that were passed in.