### PR TITLE
Method for encoding data for use in a URL

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -1,21 +1,6 @@
 "use strict";
 
 /**
- * Encode data into Base64.  When provided a string, returns a string.
- * When given a Buffer, returns a buffer.
- *
- * @param {Buffer|string} data
- * @return {Buffer|string} encoded
- */
-function base64Encode(data) {
-    if (typeof data === "string") {
-        return (new Buffer(data, "binary")).toString("base64");
-    }
-
-    return new Buffer(data.toString("base64"));
-}
-
-/**
  * Decode data from Base64.  When provided a string, returns a string.
  * When given a Buffer, returns a buffer.
  *
@@ -30,7 +15,36 @@ function base64Decode(data) {
     return new Buffer(data.toString("binary"), "base64");
 }
 
+
+/**
+ * Encode data into Base64.  When provided a string, returns a string.
+ * When given a Buffer, returns a buffer.
+ *
+ * @param {Buffer|string} data
+ * @return {Buffer|string} encoded
+ */
+function base64Encode(data) {
+    if (typeof data === "string") {
+        return (new Buffer(data, "binary")).toString("base64");
+    }
+
+    return new Buffer(data.toString("base64"));
+}
+
+
+/**
+ * Encodes data into Base64 intended for a URI. This replaces characters
+ * which could cause issues reading the value in a URI.
+ *
+ * @param {Buffer|string} data
+ * @return {Buffer|string} encoded for URI
+ */
+function base64EncodeForUri(data) {
+    return new Buffer(base64Encode(data).toString("binary").replace(/\+/g, "-").replace(/\//g, "_").replace(/\=/g, ""));
+}
+
 module.exports = {
     decode: base64Decode,
-    encode: base64Encode
+    encode: base64Encode,
+    encodeForUri: base64EncodeForUri
 };

--- a/spec/base64.spec.js
+++ b/spec/base64.spec.js
@@ -33,26 +33,26 @@ describe("base64", () => {
             name: "DEAD BEEF"
         }
     ].forEach((scenario) => {
-        it("string encodes " + scenario.name, () => {
+        it("encodes a string to a string: " + scenario.name, () => {
             var result;
 
             result = base64.encode(scenario.decoded);
             expect(result).toEqual(scenario.encoded);
         });
-        it("buffer encodes " + scenario.name, () => {
+        it("encodes a buffer to a buffer: " + scenario.name, () => {
             var result;
 
             result = base64.encode(new Buffer(scenario.decoded, "binary"));
             expect(result).toEqual(jasmine.any(Buffer));
             expect(result.toString("binary")).toEqual(scenario.encoded);
         });
-        it("string decodes " + scenario.name, () => {
+        it("decodes a string from a string" + scenario.name, () => {
             var result;
 
             result = base64.decode(scenario.encoded);
             expect(result).toEqual(scenario.decoded);
         });
-        it("buffer decodes " + scenario.name, () => {
+        it("decodes a buffer from a buffer " + scenario.name, () => {
             var result;
 
             result = base64.decode(new Buffer(scenario.encoded, "binary"));
@@ -60,11 +60,11 @@ describe("base64", () => {
             expect(result.toString("binary")).toEqual(scenario.decoded);
         });
     });
-    it("data encodes for URI", () => {
+    it("encodes a buffer for use in a URI", () => {
         var result;
 
         result = base64.encodeForUri(new Buffer("p5>T44d3?12Ui", "binary"));
         expect(result).toEqual(jasmine.any(Buffer));
-        expect(result.toString()).toBe("cDU-VDQ0ZDM_MTJVaQ");
+        expect(result.toString("ascii")).toBe("cDU-VDQ0ZDM_MTJVaQ");
     });
 });

--- a/spec/base64.spec.js
+++ b/spec/base64.spec.js
@@ -60,4 +60,11 @@ describe("base64", () => {
             expect(result.toString("binary")).toEqual(scenario.decoded);
         });
     });
+    it("data encodes for URI", () => {
+        var result;
+
+        result = base64.encodeForUri(new Buffer("p5>T44d3?12Ui", "binary"));
+        expect(result).toEqual(jasmine.any(Buffer));
+        expect(result.toString()).toBe("cDU-VDQ0ZDM_MTJVaQ");
+    });
 });


### PR DESCRIPTION
We needed to strip out the +, / and equals base64 can use in it's encoding