### PR TITLE
Add CORS middleware

### DIFF
--- a/lib/rest-middleware.js
+++ b/lib/rest-middleware.js
@@ -1,4 +1,4 @@
-module.exports = function (helmet, logger, restifyLinks) {
+module.exports = function (helmet, logger, restify, restifyLinks) {
     /**
      * Chains middleware from Helmet and other sources.
      *
@@ -44,6 +44,7 @@ module.exports = function (helmet, logger, restifyLinks) {
             server.use(helmet.noCache());
             server.use(helmet.noSniff());
             server.use(helmet.xssFilter());
+            server.use(restify.CORS());
             server.use(restifyLinks());
             server.use(standardLinks);
         }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "keywords": [
         "tokenize"
     ],
-    "author": "OpenToken Team",
+    "author": "OpenToken.io Team",
     "contributors": [
         {
             "name": "Tyler Akins",

--- a/spec/rest-middleware.spec.js
+++ b/spec/rest-middleware.spec.js
@@ -16,8 +16,8 @@ describe("restMiddleware", () => {
             helmetMock.noCache,
             helmetMock.noSniff,
             helmetMock.xssFilter,
-            restifyMock.CORS,
-            restifyLinks
+            restifyLinks,
+            restifyMock.CORS
         ].forEach((spy) => {
             expect(spy).toHaveBeenCalled();
             expect(serverMock.use).toHaveBeenCalledWith(spy);

--- a/spec/rest-middleware.spec.js
+++ b/spec/rest-middleware.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("restMiddleware", () => {
-    var helmetMock, restMiddleware, serverMock, restifyLinks;
+    var helmetMock, restMiddleware, serverMock, restifyMock, restifyLinks;
 
     /**
      * Tests the common middleware set up when calling restMiddleware.
@@ -9,14 +9,30 @@ describe("restMiddleware", () => {
      * needs to be tested there.
      */
     function expectNormalMiddlewareWasCalled () {
-        expect(helmetMock.frameguard).toHaveBeenCalled();
-        expect(helmetMock.ieNoOpen).toHaveBeenCalled();
-        expect(helmetMock.hidePoweredBy).toHaveBeenCalled();
-        expect(helmetMock.ieNoOpen).toHaveBeenCalled();
-        expect(helmetMock.noCache).toHaveBeenCalled();
-        expect(helmetMock.noSniff).toHaveBeenCalled();
-        expect(helmetMock.xssFilter).toHaveBeenCalled();
-        expect(restifyLinks).toHaveBeenCalled();
+        [
+            helmetMock.frameguard,
+            helmetMock.ieNoOpen,
+            helmetMock.hidePoweredBy,
+            helmetMock.noCache,
+            helmetMock.noSniff,
+            helmetMock.xssFilter,
+            restifyMock.CORS,
+            restifyLinks
+        ].forEach((spy) => {
+            expect(spy).toHaveBeenCalled();
+            expect(serverMock.use).toHaveBeenCalledWith(spy);
+        });
+    }
+
+    function mockMiddleware(name, methods) {
+        var middleware;
+
+        middleware = jasmine.createSpyObj(name, methods);
+        methods.forEach((methodName) => {
+            middleware[methodName].andReturn(middleware[methodName]);
+        });
+
+        return middleware;
     }
 
     beforeEach(() => {
@@ -24,7 +40,7 @@ describe("restMiddleware", () => {
 
         RestMiddleware = require("../lib/rest-middleware");
         loggerMock = require("./mock/logger-mock");
-        helmetMock = jasmine.createSpyObj("helmetMock", [
+        helmetMock = mockMiddleware("helmetMock", [
             "frameguard",
             "hidePoweredBy",
             "hsts",
@@ -36,8 +52,12 @@ describe("restMiddleware", () => {
         serverMock = jasmine.createSpyObj("serverMock", [
             "use"
         ]);
-        restifyLinks = jasmine.createSpy();
-        restMiddleware = new RestMiddleware(helmetMock, loggerMock, restifyLinks);
+        restifyMock = mockMiddleware("restifyMock", [
+            "CORS"
+        ]);
+        restifyLinks = jasmine.createSpy("restifyLinks");
+        restifyLinks.andReturn(restifyLinks);
+        restMiddleware = new RestMiddleware(helmetMock, loggerMock, restifyMock, restifyLinks);
     });
     it("calls restMiddleware without https", () => {
         restMiddleware({


### PR DESCRIPTION
This adds `restify.CORS()` to the list of middleware for standard handling of the options calls that HTTP clients will make during preflight requests.

The tests are also improved so they not only ensure that the middleware was called but also that it was added to the server via `server.use()`.

Finally, there is a change that updates the team name to try to prevent confusion with another GitHub organization.