### PR TITLE
Adding restify-router-magic for automatic route generation

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,6 +1,8 @@
+#!/usr/bin/env node
+
 "use strict";
 
-var ApiServer, config, container, logger;
+var config, container, logger;
 
 container = require("../lib/dependencies");
 
@@ -19,5 +21,5 @@ if (process.env.DEBUG) {
     config.debug = true;
 }
 
-ApiServer = container.resolve("apiServer");
-(new ApiServer()).startServerAsync();
+// Kick off the server through dependency injection
+container.resolve("apiServer")();

--- a/lib/api-server.js
+++ b/lib/api-server.js
@@ -1,25 +1,19 @@
 "use strict";
 
 module.exports = (config, WebServer) => {
-    class ApiServer {
-        constructor() {
-            this.webServer = new WebServer(config.server);
-            this.webServer.addRoute("get", "/", (req, res, next) => {
-                res.setHeader("content-type", "text/plain");
-                res.send("API running " + (new Date()) + "\n");
-                next();
-            });
-        }
+    var webServer;
 
-        /**
-         * Starts the server
-         *
-         * @return {Promise}
-         */
-        startServerAsync() {
-            return this.webServer.startServerAsync();
-        }
+    webServer = new WebServer(config.server);
+    webServer.addRoutes("./routes");
+
+    /**
+     * Starts the server
+     *
+     * @return {Promise.<*>}
+     */
+    function startServer() {
+        return webServer.startServerAsync();
     }
 
-    return ApiServer;
+    return startServer;
 }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -17,7 +17,7 @@ container.provide("config", require("../config.json"));
 // `.singleton()` = Injects the same instance to all dependencies
 container.instance("accountManager", require("./account/account-manager"));
 container.instance("accountService", require("./account/account-service"));
-container.register("ApiServer", require("./api-server"));
+container.register("apiServer", require("./api-server"));
 container.register("base64", require("./base64"));
 container.register("ciphersAndHashes", require("./ciphers-and-hashes"));
 container.instance("hotp", require("./mfa/hotp"));
@@ -46,6 +46,7 @@ container.provide("moment", require("moment"));
 container.provide("proxywrap", require("findhit-proxywrap"));
 container.provide("restify", require("restify"));
 container.provide("restifyLinks", require("restify-links"));
+container.provide("restifyRouterMagic", require("restify-router-magic"));
 container.provide("tv4", require("tv4"));
 container.provide("twofa", require("2fa"));
 container.provide("nodeValidator", require("validator"));

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -1,6 +1,8 @@
 "use strict";
 
-module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddleware) => {
+module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddleware, restifyRouterMagic) => {
+    restifyRouterMagic = promise.promisify(restifyRouterMagic);
+
     class WebServer {
         constructor(config) {
             this.configure(config);  // Sets this.config, this.restifyConfig
@@ -51,23 +53,16 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddlewa
         /**
          * This is used for setting up a verb to be called within the application
          *
-         * @param {string} method
-         * @param {string} route
-         * @param {Function} callback
+         * @param {string} routesPath
          * @return {this}
          */
-        addRoute(method, route, callback) {
-            method = method.toLowerCase();
-
-            if (method == "delete") {
-                method = "del";
-            }
-
+        addRoutes(routesPath) {
             this.addContract((server) => {
-                logger.debug("Adding route: " + method + " " + route);
-                server[method](route, callback);
-
-                return server;
+                return restifyRouterMagic(server, {
+                    routesPath: routesPath
+                }).then(() => {
+                    return server;
+                });
             });
 
             return this;

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restMiddleware, restifyRouterMagic) => {
+module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRouterMagic, restMiddleware) => {
     restifyRouterMagic = promise.promisify(restifyRouterMagic);
 
     class WebServer {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "moment": "^2.12.0",
         "restify": "opentoken-io/node-restify#proxywrap",
         "restify-links": "^1.1.0",
+        "restify-router-magic": "^1.0.1",
         "tv4": "^1.2.7",
         "validator": "^5.2.0"
     }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+    get: function (req, res, next) {
+        res.setHeader("Content-Type", "text/plain");
+        res.send("API running " + (new Date()) + "\n");
+        next();
+    }
+};

--- a/spec/api-server.spec.js
+++ b/spec/api-server.spec.js
@@ -1,19 +1,14 @@
 "use strict";
 
 describe("ApiServer", () => {
-    var create;
+    var apiServerFactory, WebServerMock;
 
     beforeEach(() => {
-        var ApiServerFactory, WebServerMock;
-
-        ApiServerFactory = require("../lib/api-server");
+        apiServerFactory = require("../lib/api-server");
         WebServerMock = require("./mock/web-server-mock");
-        create = (config) => {
-            return new (ApiServerFactory(config, WebServerMock));
-        };
     });
     it("starts a server", (done) => {
-        var apiServer, config, webServer;
+        var apiServer, config;
 
         config = {
             server: {
@@ -21,32 +16,15 @@ describe("ApiServer", () => {
                 "port": 8443
             }
         };
-        apiServer = create(config);
-        webServer = apiServer.webServer;
-        expect(webServer.config).toBe(config.server);
-        expect(apiServer).toEqual(jasmine.any(Object));
-        expect(webServer.startServerAsync).not.toHaveBeenCalled();
-        apiServer.startServerAsync().then(() => {
-            expect(webServer.startServerAsync).toHaveBeenCalled();
+        apiServer = apiServerFactory(config, WebServerMock);
+        expect(apiServer).toEqual(jasmine.any(Function));
+        expect(WebServerMock.mostRecentInstance.startServerAsync).not.toHaveBeenCalled();
+        apiServer().then(() => {
+            expect(WebServerMock.mostRecentInstance.startServerAsync).toHaveBeenCalled();
         }).then(done, done);
     });
     it("sets up a route", () => {
-        var addRouteCallback, apiServer, next, req, res, webServer;
-
-        res = jasmine.createSpyObj("resMock", [
-            "send",
-            "setHeader"
-        ]);
-        next = jasmine.createSpy("nextMock");
-        apiServer = create({});
-        webServer = apiServer.webServer;
-        expect(webServer.addRoute).toHaveBeenCalledWith("get", "/", jasmine.any(Function));
-        addRouteCallback = webServer.addRoute.mostRecentCall.args[2];
-        expect(() => {
-            addRouteCallback(req, res, next);
-        }).not.toThrow();
-        expect(res.setHeader).toHaveBeenCalled();
-        expect(res.send).toHaveBeenCalled();
-        expect(next).toHaveBeenCalled();
+        apiServerFactory({}, WebServerMock);
+        expect(WebServerMock.mostRecentInstance.addRoutes).toHaveBeenCalledWith("./routes");
     });
 });

--- a/spec/mock/web-server-mock.js
+++ b/spec/mock/web-server-mock.js
@@ -13,12 +13,13 @@ class WebServerMock {
         this.config = config;
 
         [
-            "addRoute",
+            "addRoutes",
             "startServerAsync"
         ].forEach((methodName) => {
             this[methodName] = jasmine.createSpy(methodName);
         });
         this.startServerAsync.andReturn(promiseMock.resolve());
+        WebServerMock.mostRecentInstance = this;
     }
 }
 


### PR DESCRIPTION
**NOTE** *Do not approve until after reviewing [restify-router-magic](https://github.com/tests-always-included/restify-router-magic)!*

Added the third party library.

Changed `WebServer.addRoute()` to `WebServer.addRoutes(folder)` and
that hooks into restify-router-magic.

Changed ApiServer from a class into an exported function.  Calling the
function starts the server.

Added a shebang and changed the permissions of `bin/server.js` so it can
start up from the command line.