### PR TITLE
Implement significantly stricter linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage/
+node_modules/

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,233 @@
+parserOptions:
+    ecmaVersion: 6
+env:
+    es6: true
+    jasmine: true
+    node: true
+extends: eslint:recommended
+rules:
+    accessor-pairs: error
+    array-bracket-spacing:
+        - error
+        - never
+    array-callback-return: error
+    arrow-body-style:
+        - error
+        - always
+    arrow-parens: error
+    arrow-spacing: error
+    block-spacing:
+        - error
+        - never
+    brace-style: error
+    comma-dangle: error
+    comma-spacing: error
+    comma-style: error
+    complexity:
+        - error
+        - 10
+    computed-property-spacing: error
+    consistent-return: error
+    consistent-this: error
+    constructor-super: error
+    curly: error
+    default-case: error
+    dot-notation: error
+    eol-last: error
+    eqeqeq: error
+    generator-star-spacing: error
+    global-require: off
+    guard-for-in: error
+    indent: error
+    init-declarations:
+        - error
+        - never
+    jsx-quotes: error
+    key-spacing: error
+    keyword-spacing: error
+    linebreak-style: error
+    lines-around-comment:
+        - error
+        -
+            allowBlockStart: true
+            allowObjectStart: true
+            allowArrayStart: true
+    max-statements-per-line: error
+    new-cap: error
+    new-parens: error
+    newline-after-var: error
+    newline-before-return: error
+    no-alert: error
+    no-array-constructor: error
+    no-bitwise: error
+    no-caller: error
+    no-case-declarations: error
+    no-catch-shadow: error
+    no-class-assign: error
+    no-cond-assign: error
+    no-confusing-arrow: error
+    no-console: off
+    no-const-assign: error
+    no-constant-condition: error
+    no-continue: error
+    no-delete-var: error
+    no-dupe-args: error
+    no-dupe-class-members: error
+    no-dupe-keys: error
+    no-duplicate-case: error
+    no-duplicate-imports: error
+    no-else-return: error
+    no-empty: error
+    no-empty-character-class: error
+    no-empty-pattern: error
+    no-eq-null: error
+    no-eval: error
+    no-extend-native: error
+    no-extra-bind: error
+    no-extra-boolean-cast: error
+    no-extra-label: error
+    no-extra-parens: error
+    no-extra-semi: error
+    no-fallthrough: error
+    no-func-assign: error
+    no-implied-eval: error
+    no-inline-comments: error
+    no-inner-declarations: error
+    no-invalid-this: error
+    no-invalid-regexp: error
+    no-irregular-whitespace: error
+    no-iterator: error
+    no-label-var: error
+    no-labels: error
+    no-lone-blocks: error
+    no-lonely-if: error
+    no-loop-func: error
+    no-mixed-spaces-and-tabs: error
+    no-multi-spaces: error
+    no-multi-str: error
+    no-multiple-empty-lines:
+        - error
+        -
+            max: 2
+    no-native-reassign: error
+    no-negated-condition: error
+    no-nested-ternary: error
+    no-new: error
+    no-new-func: error
+    no-new-object: error
+    no-new-symbol: error
+    no-new-wrappers: error
+    no-obj-calls: error
+    no-octal: error
+    no-octal-escape: error
+    no-path-concat: error
+    no-plusplus: error
+    no-process-exit: error
+    no-proto: error
+    no-redeclare: error
+    no-regex-spaces: error
+    no-restricted-globals: error
+    no-return-assign: error
+    no-script-url: error
+    no-self-assign: error
+    no-self-compare: error
+    no-sequences: error
+    no-shadow: error
+    no-shadow-restricted-names: error
+    no-spaced-func: error
+    no-sparse-arrays: error
+    no-sync: error
+    no-ternary: error
+    no-this-before-super: error
+    no-throw-literal: error
+    no-trailing-spaces: error
+    no-undef: error
+    no-undef-init: error
+    no-undefined: error
+    no-underscore-dangle: error
+    no-unexpected-multiline: error
+    no-unmodified-loop-condition: error
+    no-unneeded-ternary: error
+    no-unreachable: error
+    no-unsafe-finally: error
+    no-unused-expressions: error
+    no-unused-labels: error
+    no-unused-vars: error
+    no-use-before-define: error
+    no-useless-call: error
+    no-useless-computed-key: error
+    no-useless-concat: error
+    no-useless-constructor: error
+    no-useless-escape: error
+    no-void: error
+    no-warning-comments: warn
+    no-whitespace-before-property: error
+    no-with: error
+    object-curly-spacing: error
+    object-property-newline: error
+    object-shorthand: error
+    one-var: error
+    operator-assignment: error
+    operator-linebreak:
+        - error
+        - none
+    padded-blocks:
+        - error
+        - never
+    prefer-arrow-callback:
+        - error
+        -
+            allowNamedFunctions: true
+    prefer-const: error
+    prefer-template: error
+    quote-props:
+        - error
+        - as-needed
+    quotes: error
+    radix: error
+    require-jsdoc:
+        - error
+        -
+            require:
+                FunctionDeclaration: true
+                MethodDefinition: true
+                ClassDeclaration: true
+    require-yield: error
+    semi: error
+    semi-spacing: error
+    sort-imports: error
+    sort-vars:
+        - error
+        -
+            ignoreCase: true
+    space-before-blocks: error
+    space-before-function-paren:
+        - error
+        -
+            anonymous: always
+            named: never
+    space-in-parens: error
+    space-infix-ops:
+        - error
+        -
+            int32Hint: false
+    space-unary-ops: error
+    spaced-comment: error
+    strict: error
+    template-curly-spacing: error
+    use-isnan: error
+    valid-jsdoc:
+        - error
+        -
+            prefer:
+                returns: return
+            preferType:
+                object: Object
+                String: string
+            requireParamDescription: false
+            requireReturn: false
+            requireReturnDescription: false
+    valid-typeof: error
+    vars-on-top: error
+    wrap-iife: error
+    yield-star-spacing: error

--- a/bin/server.js
+++ b/bin/server.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-var config, container, logger;
+var config, container, logger, path;
 
 container = require("../lib/dependencies");
 
@@ -12,8 +12,8 @@ logger = container.resolve("logger");
 
 // Allow overriding of the port
 if (process.env.PORT) {
-    logger.info("Environment variable overriding port (was " + config.server.port + ", is now " + process.env.PORT + ")");
-    config.server.port = process.env.PORT;
+    logger.info(`Environment variable overriding port (was ${config.server.port}, is now ${process.env.PORT})`);
+    config.server.port = +process.env.PORT;
 }
 
 if (process.env.DEBUG) {
@@ -21,7 +21,8 @@ if (process.env.DEBUG) {
     config.debug = true;
 }
 
-container.resolve("bootstrap")(__dirname + "/..").then(() => {
+path = container.resolve("path");
+container.resolve("bootstrap")(path.resolve(__dirname, "..")).then(() => {
     // Kick off the server through dependency injection
     container.resolve("apiServer")();
 });

--- a/debug/list-ciphers-and-hashes.js
+++ b/debug/list-ciphers-and-hashes.js
@@ -12,7 +12,7 @@ Object.keys(ciphersAndHashes.ciphers).forEach((cipherName) => {
     var cipher;
 
     cipher = ciphersAndHashes.ciphers[cipherName];
-    console.log(cipherName + "\t" + cipher.ivBytes + "\t" + cipher.keyBytes);
+    console.log(`${cipherName}\t${cipher.ivBytes}\t${cipher.keyBytes}`);
 });
 
 console.log("");
@@ -22,5 +22,5 @@ Object.keys(ciphersAndHashes.hashes).forEach((hashName) => {
     var hash;
 
     hash = ciphersAndHashes.hashes[hashName];
-    console.log(hashName + "\t" + hash.hashLength);
+    console.log(`${hashName}\t${hash.hashLength}`);
 });

--- a/debug/test-cipher.js
+++ b/debug/test-cipher.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint no-process-exit:0 */
 "use strict";
 
 var algorithm, crypto, data, deciphered, iterations, key, length, result, timer;
@@ -7,7 +8,7 @@ crypto = require("crypto");
 timer = require("./timer");
 
 if (process.argv.length < 4) {
-    console.log("Usage:")
+    console.log("Usage:");
     console.log("");
     console.log("    test-cipher.js algorithm data-length [iterations]");
     console.log("");
@@ -55,4 +56,4 @@ timer.run(() => {
         cipher.final()
     ]);
 }, iterations, "decrypt");
-console.log("correct:", deciphered.toString("hex") == data.toString("hex"));
+console.log("correct:", deciphered.toString("hex") === data.toString("hex"));

--- a/debug/test-hash-compare.js
+++ b/debug/test-hash-compare.js
@@ -29,21 +29,27 @@ goodSmall.fill(0x42);
 bad = new Buffer(size);
 bad.fill(0x00);
 
+/**
+ * Runs the test for a given number of iterations
+ *
+ * @param {number} maxTimes Number of iterations
+ */
 function runIterations(maxTimes) {
-    var badTimes, goodTimes, goodSmallTimes, iterations, start, timeToRunFor;
+    var badTimes, goodTimes, iterations, start, timeToRunFor;
 
     iterations = 0;
-    while(iterations < maxTimes) {
+
+    while (iterations < maxTimes) {
         goodTimes = 0;
-        goodSmallTimes = 0;
         badTimes = 0;
         timeToRunFor = options[0];
 
-        console.log("Running " + (iterations + 1) + " out of " + maxTimes + "...");
+        console.log(`Running ${iterations + 1} out of ${maxTimes}...`);
 
         // run good
         start = process.hrtime();
-        while((process.hrtime()[0] - start[0]) < timeToRunFor) {
+
+        while (process.hrtime()[0] - start[0] < timeToRunFor) {
             secureHash.compare(against, good);
             goodTimes += 1;
         }
@@ -51,7 +57,8 @@ function runIterations(maxTimes) {
         console.log("          Times Good Hashes Ran: ", goodTimes);
 
         start = process.hrtime();
-        while((process.hrtime()[0] - start[0]) < timeToRunFor) {
+
+        while (process.hrtime()[0] - start[0] < timeToRunFor) {
             secureHash.compare(against, goodSmall);
             goodTimes += 1;
         }
@@ -60,7 +67,8 @@ function runIterations(maxTimes) {
 
         // run bad
         start = process.hrtime();
-        while((process.hrtime()[0] - start[0]) < timeToRunFor) {
+
+        while (process.hrtime()[0] - start[0] < timeToRunFor) {
             secureHash.compare(against, bad);
             badTimes += 1;
         }

--- a/debug/test-hmac.js
+++ b/debug/test-hmac.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint no-process-exit:0 */
 "use strict";
 
 var crypto, data, dataLength, digest, iterations, key, result, timer;
@@ -7,7 +8,7 @@ crypto = require("crypto");
 timer = require("./timer");
 
 if (process.argv.length < 4) {
-    console.log("Usage:")
+    console.log("Usage:");
     console.log("");
     console.log("    test-hmac.js digest data_length [iterations]");
     console.log("");
@@ -20,7 +21,7 @@ dataLength = +process.argv[3];
 iterations = +(process.argv[4] || 1);
 console.log("digest:", digest);
 
-if (dataLength == 0) {
+if (dataLength === 0) {
     key = new Buffer("This is a test key.", "binary");
     data = new Buffer("This is a test message.", "binary");
     console.log("test:", true);

--- a/debug/test-pbkdf2.js
+++ b/debug/test-pbkdf2.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint no-process-exit:0 no-sync:0 */
 "use strict";
 
 var crypto, digest, iterations, key, result, rounds, timer;
@@ -7,7 +8,7 @@ crypto = require("crypto");
 timer = require("./timer");
 
 if (process.argv.length < 4) {
-    console.log("Usage:")
+    console.log("Usage:");
     console.log("");
     console.log("    test-pbkdf2.js digest rounds [iterations]");
     process.exit();

--- a/debug/timer.js
+++ b/debug/timer.js
@@ -4,8 +4,8 @@
 /**
  * Shows the timing information stats with an optional prefix.
  *
- * @param {Object} stats
- * @param {string} [prefix]
+ * @param {Object} stats Statistics to show (key/value pairs)
+ * @param {string} [prefix] Prefix to add to the display of each key/value
  */
 function show(stats, prefix) {
     if (prefix) {
@@ -15,7 +15,7 @@ function show(stats, prefix) {
     }
 
     Object.keys(stats).forEach((key) => {
-        console.log(prefix + key + ":", stats[key]);
+        console.log(`${prefix}${key}:`, stats[key]);
     });
 }
 
@@ -23,12 +23,12 @@ function show(stats, prefix) {
 /**
  * Times a callback for a number of iterations.
  *
- * @param {Function} callback
- * @param {number} iterations
- * @return {Object} stats
+ * @param {Function} callback The function to execute
+ * @param {number} iterations How many times to call it
+ * @return {Object} stats The timing results, key/value pairs
  */
 function time(callback, iterations) {
-    var elapsed, end, i, start;
+    var end, i, start, total;
 
     iterations = iterations || 1;
     start = process.hrtime();
@@ -38,12 +38,12 @@ function time(callback, iterations) {
     }
 
     end = process.hrtime();
-    elapsed = (end[0] - start[0]) + (end[1] - start[1]) / 1000000000;
+    total = end[0] - start[0] + (end[1] - start[1]) / 1000000000;
 
     return {
-        average: elapsed / iterations,
-        iterations: iterations,
-        total: elapsed
+        average: total / iterations,
+        iterations,
+        total
     };
 }
 
@@ -51,13 +51,13 @@ module.exports = {
     /**
      * Combines the "time" and "run" functions.
      *
-     * @param {Function} callback
-     * @param {number} iterations
-     * @param {string} [prefix]
+     * @param {Function} callback What to run
+     * @param {number} iterations How many times to run it
+     * @param {string} [prefix] The prefix to prepend when displaying stats
      */
-    run: function (callback, iterations, prefix) {
+    run(callback, iterations, prefix) {
         show(time(callback, iterations), prefix);
     },
-    show: show,
-    time: time
-}
+    show,
+    time
+};

--- a/lib/account/account-manager.js
+++ b/lib/account/account-manager.js
@@ -57,11 +57,11 @@ module.exports = function (accountService, config, hotp, otDate, promise, random
      * @throws {Error}
      */
     function checkMfa(mfaKey, previousMfa, currentMfa) {
-        if (! hotp.verifyToken(mfaKey, previousMfa, 1)) {
+        if (!hotp.verifyToken(mfaKey, previousMfa, 1)) {
             throw new Error("Previous MFA Token did not validate");
         }
 
-        if (! hotp.verifyToken(mfaKey, currentMfa)) {
+        if (!hotp.verifyToken(mfaKey, currentMfa)) {
             throw new Error("Current MFA Token did not validate");
         }
     }
@@ -125,7 +125,7 @@ module.exports = function (accountService, config, hotp, otDate, promise, random
      * data off to the account service for updating/putting data into
      * the account record.
      *
-     * @param {accountManager~registrationInfo} accountInfo
+     * @param {accountManager~registrationInfo} registrationInfo
      * @return {Promise.<accountManager~completionInfo>}
      */
     function signupCompleteAsync(registrationInfo) {
@@ -188,8 +188,8 @@ module.exports = function (accountService, config, hotp, otDate, promise, random
     }
 
     return {
-        signupCompleteAsync: signupCompleteAsync,
-        signupConfirmAsync: signupConfirmAsync,
-        signupInitiationAsync: signupInitiationAsync
+        signupCompleteAsync,
+        signupConfirmAsync,
+        signupInitiationAsync
     };
 };

--- a/lib/account/account-service.js
+++ b/lib/account/account-service.js
@@ -33,11 +33,55 @@
  */
 
 module.exports = function (config, secureHash, storage) {
-    var accountConfig, accountDirName, registrationDirName, storage;
+    var accountConfig, accountDirName, registrationDirName;
 
     accountConfig = config.account || {};
     accountDirName = accountConfig.accountDir || "account/";
     registrationDirName = accountConfig.registrationDir || "registration/";
+
+    /**
+     * Gets the key where the account will be/is stored.
+     *
+     * @param {string} prefix
+     * @param {string} idToHash
+     * @return {Promise.<string>}
+     */
+    function getDirectoryAsync(prefix, idToHash) {
+        return secureHash.hashAsync(idToHash, accountConfig.idHash).then((hashedId) => {
+            return prefix + hashedId;
+        });
+    }
+
+
+    /**
+     * Gets the account file from the directory.
+     *
+     * TODO: Decrypt data
+     *
+     * @param {string} directory
+     * @return {Promise.<accountService~accountFile>}
+     */
+    function getAsync(directory) {
+        return storage.getAsync(directory).then((accountFile) => {
+            return JSON.parse(accountFile.toString("binary"));
+        });
+    }
+
+
+    /**
+     * Creates the account file in the account directory.
+     *
+     * @param {string} accountId
+     * @param {accountService~accountFile} accountFile
+     * @param {s3~putOptions} options
+     * @return {Promise.<boolean>}
+     */
+    function makeAccountFileAsync(accountId, accountFile, options) {
+        return getDirectoryAsync(accountDirName, accountId).then((accountKey) => {
+            return storage.putAsync(accountKey, JSON.stringify(accountFile), options);
+        });
+    }
+
 
     /**
      * Completes the sign up of the account with more information from the
@@ -69,36 +113,6 @@ module.exports = function (config, secureHash, storage) {
 
 
     /**
-     * Creates the account file in the account directory.
-     *
-     * @param {string} accountId
-     * @param {accountService~accountFile} accountFile
-     * @param {s3~putOptions} options
-     * @return {Promise.<boolean>}
-     */
-    function makeAccountFileAsync(accountId, accountFile, options) {
-        return getDirectoryAsync(accountDirName, accountId).then((accountKey) => {
-            return storage.putAsync(accountKey, JSON.stringify(accountFile), options);
-        });
-    }
-
-
-    /**
-     * Gets the account file from the directory.
-     *
-     * TODO: Decrypt data
-     *
-     * @param {string} directory
-     * @return {Promise.<accountService~accountFile>}
-     */
-    function getAsync(directory) {
-        return storage.getAsync(directory).then((accountFile) => {
-            return JSON.parse(accountFile.toString("binary"));
-        });
-    }
-
-
-    /**
      * Get the registration file when it's still in the registration directory.
      * This is to eliminate one step for the manager getting the directory
      * and then requesting the file.
@@ -109,20 +123,6 @@ module.exports = function (config, secureHash, storage) {
     function getRegistrationFileAsync(regId) {
         return getDirectoryAsync(registrationDirName, regId).then(getAsync).then((accountFile) => {
             return accountFile;
-        });
-    }
-
-
-    /**
-     * Gets the key where the account will be/is stored.
-     *
-     * @param {string} prefix
-     * @param {string} idToHash
-     * @return {Promise.<string>}
-     */
-    function getDirectoryAsync(prefix, idToHash) {
-        return secureHash.hashAsync(idToHash, accountConfig.idHash).then((hashedId) => {
-            return prefix + hashedId;
         });
     }
 
@@ -143,14 +143,14 @@ module.exports = function (config, secureHash, storage) {
             return storage.putAsync(directory, JSON.stringify(accountFile), options);
         }).then(() => {
             return {
-                regId: regId
+                regId
             };
         });
     }
 
     return {
-        completeAsync: completeAsync,
-        getRegistrationFileAsync: getRegistrationFileAsync,
-        signupInitiateAsync: signupInitiateAsync
+        completeAsync,
+        getRegistrationFileAsync,
+        signupInitiateAsync
     };
 };

--- a/lib/api-server.js
+++ b/lib/api-server.js
@@ -16,4 +16,4 @@ module.exports = (config, WebServer) => {
     }
 
     return startServerAsync;
-}
+};

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -48,7 +48,7 @@ function base64EncodeForUri(data) {
         encodedData = base64Encode(data).toString("binary");
     }
 
-    return encodedData.replace(/\+/g, "-").replace(/\//g, "_").replace(/\=/g, "");
+    return encodedData.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
 module.exports = function () {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,8 +1,25 @@
+"use strict";
+
 /**
  * Finish configuration, load necessary files, and perform other
  * asynchronous tasks that are required for the software to run properly.
+ *
+ * @param {Object} config
+ * @param {Object} path Node module
+ * @param {Object} promise
+ * @param {Object} schema
+ * @return {Function} Factory
  */
 module.exports = (config, path, promise, schema) => {
+    /**
+     * Ensures the configuration is an object and that the schema path
+     * is set up correctly.  Returns the schema path to use for loading
+     * schemas so the rest of the config can be validated.
+     *
+     * @param {string} baseDir Used instead of __dirname
+     * @return {string}
+     * @throws {Error} when configuration is wrong
+     */
     function checkConfigBasic(baseDir) {
         if (typeof config !== "object" || !config) {
             throw new Error("Configuration is not an object");
@@ -15,13 +32,19 @@ module.exports = (config, path, promise, schema) => {
         return path.resolve(baseDir, config.schemaPath);
     }
 
+
+    /**
+     * Checks for missing schemas
+     *
+     * @throws {Error} when schemas are missing.
+     */
     function checkForMissingSchemas() {
         var missing;
 
         missing = schema.getMissingSchemas();
 
         if (missing.length) {
-            throw new Error("Unresolved schema references: " + missing.join(", "));
+            throw new Error(`Unresolved schema references: ${missing.join(", ")}`);
         }
     }
 
@@ -29,7 +52,7 @@ module.exports = (config, path, promise, schema) => {
         return promise.try(() => {
             return checkConfigBasic(baseDir);
         }).then((schemaPath) => {
-            return schema.loadSchemaFolderAsync(schemaPath + "/");
+            return schema.loadSchemaFolderAsync(schemaPath + path.sep);
         }).then(() => {
             return checkForMissingSchemas();
         }).then(() => {
@@ -38,7 +61,7 @@ module.exports = (config, path, promise, schema) => {
             result = schema.validate(config, "/config/config");
 
             if (result) {
-                throw new Error("Config did not validate: " + result.error.message + " " + result.error.dataPath + " " + result.error.schemaPath);
+                throw new Error(`Config did not validate: ${result.error.message} ${result.error.dataPath} ${result.error.schemaPath}`);
             }
         });
     };

--- a/lib/buffer-serializer.js
+++ b/lib/buffer-serializer.js
@@ -1,3 +1,6 @@
+/**
+ * Configures the buffer serializer module to also handle OtDate objects.
+ */
 "use strict";
 
 var configured;
@@ -5,7 +8,7 @@ var configured;
 configured = false;
 
 module.exports = (bufferSerializerModule, OtDate) => {
-    if (! configured) {
+    if (!configured) {
         bufferSerializerModule.register("OtDate", (obj) => {
             return obj instanceof OtDate;
         }, (obj, buffWriter) => {
@@ -14,6 +17,7 @@ module.exports = (bufferSerializerModule, OtDate) => {
             var date;
 
             date = bufferSerializerModule.fromBufferInternal(buffReader);
+
             return OtDate.fromDate(date);
         });
         configured = true;

--- a/lib/ciphers-and-hashes.js
+++ b/lib/ciphers-and-hashes.js
@@ -4,6 +4,7 @@
  * Never delete anything from this file.  Only append new codes, otherwise
  * secrets that are locked away may not ever work again.
  */
+"use strict";
 
 var ciphers, hashes;
 
@@ -126,17 +127,20 @@ ciphers = {
     "bf-cbc": {
         code: 20,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "bf-cfb": {
         code: 21,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "bf-ofb": {
         code: 22,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "camellia-128-cbc": {
         code: 23,
@@ -216,17 +220,20 @@ ciphers = {
     "cast5-cbc": {
         code: 38,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "cast5-cfb": {
         code: 39,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "cast5-ofb": {
         code: 40,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "des-cbc": {
         code: 41,
@@ -316,27 +323,32 @@ ciphers = {
     "rc2-40-cbc": {
         code: 58,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "rc2-64-cbc": {
         code: 59,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "rc2-cbc": {
         code: 60,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "rc2-cfb": {
         code: 61,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "rc2-ofb": {
         code: 62,
         ivBytes: 8,
-        keyBytes: 128  // Arbitrary number, anything greater than 0 works
+        keyBytes: 128
+        // keyBytes is an arbitrary number, anything greater than 0 works
     },
     "seed-cbc": {
         code: 63,
@@ -453,8 +465,8 @@ function assignNameAndIndexByCode(source) {
 
 
 module.exports = {
-    ciphers: ciphers,
+    ciphers,
     ciphersByCode: assignNameAndIndexByCode(ciphers),
-    hashes: hashes,
+    hashes,
     hashesByCode: assignNameAndIndexByCode(hashes)
-}
+};

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var container, moduleDefs, Dizzy;
+var container, Dizzy, moduleDefs;
 
 Dizzy = require("dizzy");
 container = new Dizzy();
@@ -48,12 +48,13 @@ container.register("setIntervalFn", setInterval);
 
 // 3rd party libraries.
 // The key is the name in the container, the value is the name of the module.
+// Most of these are libraries, but some are node built-in modules.
 moduleDefs = {
     awsSdk: "aws-sdk",
     bluebird: "bluebird",
     bufferSerializerModule: "buffer-serializer",
-    crypto: "crypto", // node built-in
-    fs: "fs", // node built-in
+    crypto: "crypto",
+    fs: "fs",
     glob: "glob",
     helmet: "helmet",
     moment: "moment",

--- a/lib/encryption.js
+++ b/lib/encryption.js
@@ -99,7 +99,8 @@ module.exports = function (ciphersAndHashes, crypto, promise, random) {
                 name: cipher.name
             },
             cipherKey: {
-                bytes: cipher.keyBytes, // Note: not cipherKey.keyBytes!
+                // Note: not cipherKey.keyBytes!
+                bytes: cipher.keyBytes,
                 code: cipherKey.code,
                 iterations: Math.min(cipherIterations, 1000),
                 name: cipherKey.name
@@ -110,251 +111,13 @@ module.exports = function (ciphersAndHashes, crypto, promise, random) {
                 name: hmac.name
             },
             hmacKey: {
-                bytes: 32, // Arbitrary
+                // Arbitrary number of bytes
+                bytes: 32,
                 code: hmacKey.code,
                 iterations: Math.min(hmacIterations, 1000),
                 name: hmacKey.name
             }
-        }
-    }
-
-
-    /**
-     * Decrypts data
-     *
-     * @param {(Buffer|string)} data
-     * @param {(Buffer|string)} keySource
-     * @return {Promise.<Buffer>}
-     */
-    function decryptAsync(data, keySource) {
-        if (typeof data === "string") {
-            data = new Buffer(data, "binary");
-        }
-
-        if (typeof keySource === "string") {
-            keySource = new Buffer(keySource, "binary");
-        }
-
-        return readHeaderAsync(data).then((header) => {
-            var parameters, posHmac, posIv, posEncrypted, posEnd;
-
-            parameters = parametersFromHeader(header);
-
-            // Assign position variables to the first byte of that spot
-            posHmac = header.headerLength;
-            posIv = posHmac + parameters.hmac.hmacBytes;
-            posEncrypted = posIv + parameters.cipher.ivBytes;
-            posEnd = posEncrypted + header.encryptedDataLength;
-
-            return promise.props({
-                cipherKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.cipherKey.iterations, parameters.cipherKey.bytes, parameters.cipherKey.name),
-                hmacKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.hmacKey.iterations, parameters.hmacKey.bytes, parameters.hmacKey.name)
-            }).then((bits) => {
-                var decipher, encrypted, hmac, hmacDigest, hmacExpected, iv;
-
-                // Extract the embedded record fields
-                hmacExpected = data.slice(posHmac, posIv);
-                iv = data.slice(posIv, posEncrypted);
-                encrypted = data.slice(posEncrypted, posEnd);
-
-                // Create a new HMAC object
-                hmac = crypto.createHmac(parameters.hmac.name, bits.hmacKey);
-
-                // Add the record header, iv and the encrypted message
-                hmac.update(data.slice(0, posHmac)); // header bytes
-                hmac.update(iv);
-                hmac.update(encrypted);
-                hmacDigest = hmac.digest();
-
-                // Double check - NOTE: the result of 0 means they are the same
-                if (Buffer.compare(hmacExpected, hmacDigest)) {
-                    throw new Error("HMAC invalid");
-                }
-
-                decipher = crypto.createDecipheriv(parameters.cipher.name, bits.cipherKey, iv);
-
-                return Buffer.concat([
-                    decipher.update(encrypted),
-                    decipher.final()
-                ]);
-            });
-        });
-    }
-
-
-    /**
-     * Generate a buffer describing the encryption record.
-     *
-     * @param {encryption~parameters} parameters
-     * @param {number} dataLength
-     * @return {Buffer}
-     */
-    function encryptionHeader(parameters, encryptedDataLength) {
-        var buff;
-
-        buff = new Buffer(17);
-        buff[0] = 0; // Version
-        buff[1] = parameters.hmac.code;
-        buff[2] = parameters.hmacKey.code;
-        buff.writeUInt32LE(parameters.hmacKey.iterations, 3);
-        buff[7] = parameters.cipher.code;
-        buff[8] = parameters.cipherKey.code;
-        buff.writeUInt32LE(parameters.cipherKey.iterations, 9);
-        buff.writeUInt32LE(encryptedDataLength, 13);
-
-        return buff;
-    }
-
-
-    /**
-     * Builds a record that looks like this:
-     *
-     *   HEADER HMAC IV ENCRYPTED
-     *
-     * The HMAC validates a buffer that looks like this:
-     *
-     *   HEADER IV ENCRYPTED
-     *
-     * The header is first so we know the HMAC length, but we also want to
-     * hash the header to make sure the header was not modified.  Because
-     * of those conderns, it was decided to encode and process in the
-     * above described method.
-     *
-     * Zero byte salts are used because there is nowhere to store the salt
-     * safely that is separate from the keys that will be used for
-     * encryption and decryption.  Also, the generated keys are randomly
-     * generated, so we shouldn't need to worry about the strength here.
-     * The key derivation algorithm is mostly used to generate a key of the
-     * right length and to slow down attacks with the number of iterations.
-     *
-     * @param {(Buffer|string)} data
-     * @param {(Buffer|string)| keySource
-     * @param {encryption~methodConfig} hmacConfig
-     * @param {encryption~methodConfig} cipherConfig
-     * @return {Promise.<Buffer>}
-     */
-    function encryptAsync(data, keySource, hmacConfig, cipherConfig) {
-        if (typeof data === "string") {
-            data = new Buffer(data, "binary");
-        }
-
-        if (typeof keySource === "string") {
-            keySource = new Buffer(keySource, "binary");
-        }
-
-        return parametersFromConfigAsync(hmacConfig, cipherConfig).then((parameters) => {
-            return promise.props({
-                cipherKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.cipherKey.iterations, parameters.cipherKey.bytes, parameters.cipherKey.name),
-                iv: random.bufferAsync(parameters.cipher.ivBytes),
-                hmacKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.hmacKey.iterations, parameters.hmacKey.bytes, parameters.hmacKey.name)
-            }).then((bits) => {
-                var bufferList, cipher, encryptedDataLength, hmac;
-
-                // Encrypt and store into the buffer.  Also add IV to buffer.
-                cipher = crypto.createCipheriv(parameters.cipher.name, bits.cipherKey, bits.iv);
-                bufferList = [
-                    null, // Header goes here
-                    null, // HMAC goes here
-                    bits.iv,
-                    cipher.update(data),
-                    cipher.final()
-                ];
-                data.fill(0);  // Attempt to destroy original data
-                encryptedDataLength = bufferList[3].length + bufferList[4].length;
-
-                // The header can now be created
-                bufferList[0] = encryptionHeader(parameters, encryptedDataLength);
-
-                // Create the secure hash and insert it into the buffer list
-                hmac = crypto.createHmac(parameters.hmac.name, bits.hmacKey);
-                hmac.update(bufferList[0]);  // Header
-                hmac.update(bufferList[2]);  // IV
-                hmac.update(bufferList[3]);  // Some/most encrypted data
-                hmac.update(bufferList[4]);  // Remaining encrypted data
-                bufferList[1] = hmac.digest();
-
-                return Buffer.concat(bufferList);
-            });
-        });
-    }
-
-
-    /**
-     * Looks up encryption-related objects.  This creates an object with
-     * all of the necessary settings to generate headers and perform the
-     * encryption / decryption.
-     *
-     * @param {encryption~methodConfig} hmacConfig
-     * @param {encryption~methodConfig} cipherConfig
-     * @return {Promise.<encryption~parameters>}
-     */
-    function parametersFromConfigAsync(hmacConfig, cipherConfig) {
-        return promise.try(() => {
-            var cipher, cipherKey, hmac, hmacKey;
-
-            /**
-             * Looks up a cipher or hmac by name.  When it does not exist,
-             * this throws an exception.
-             *
-             * @param {string} name
-             * @param {Object} obj
-             * @param {string} humanReadable What we're seeking
-             * @return {*} obj[name]
-             * @throws Error when [name] does not exist on object
-             */
-            function lookup(name, obj, humanReadable) {
-                if (! obj[name]) {
-                    throw new Error("Invalid " + humanReadable + " name: " + name);
-                }
-
-                return obj[name];
-            }
-
-            // Lookup algorithm definitions
-            hmac = lookup(hmacConfig.algorithm, ciphersAndHashes.hashes, "HMAC Algorithm");
-            hmacKey = lookup(hmacConfig.digest, ciphersAndHashes.hashes, "HMAC Key Digest");
-            cipher = lookup(cipherConfig.algorithm, ciphersAndHashes.ciphers, "Cipher Algorithm");
-            cipherKey = lookup(cipherConfig.digest, ciphersAndHashes.hashes, "Cipher Key Digest");
-
-            return buildParameters(hmac, hmacKey, hmacConfig.iterations, cipher, cipherKey, cipherConfig.iterations);
-        });
-    }
-
-
-    /**
-     * Gets a parameters object from the fields in a header.
-     *
-     * @param {encryption~header}
-     * @return {encryption~parameters}
-     */
-    function parametersFromHeader(header) {
-        var cipher, cipherKey, hmac, hmacKey;
-
-        /**
-         * Looks up a cipher or hmac by name.  When it does not exist,
-         * this throws an exception.
-         *
-         * @param {number} code
-         * @param {Object} obj
-         * @param {string} humanReadable What we're seeking
-         * @return {*} obj[name]
-         * @throws {Error} when [name] does not exist on object
-         */
-        function lookup(code, obj, humanReadable) {
-            if (! obj[code]) {
-                throw new Error("Invalid " + humanReadable + " code: " + code);
-            }
-
-            return obj[code];
-        }
-
-        // Lookup algorithm definitions
-        hmac = lookup(header.hmacAlgoCode, ciphersAndHashes.hashesByCode, "HMAC Algorithm");
-        hmacKey = lookup(header.hmacKeyDigest, ciphersAndHashes.hashesByCode, "HMAC Key Digest");
-        cipher = lookup(header.cipherAlgoCode, ciphersAndHashes.ciphersByCode, "Cipher Algorithm");
-        cipherKey = lookup(header.cipherKeyDigest, ciphersAndHashes.hashesByCode, "Cipher Key Digest");
-
-        return buildParameters(hmac, hmacKey, header.hmacKeyIterations, cipher, cipherKey, header.cipherKeyIterations);
+        };
     }
 
 
@@ -385,12 +148,266 @@ module.exports = function (ciphersAndHashes, crypto, promise, random) {
     }
 
 
+    /**
+     * Gets a parameters object from the fields in a header.
+     *
+     * @param {encryption~header} header
+     * @return {encryption~parameters}
+     */
+    function parametersFromHeader(header) {
+        var cipher, cipherKey, hmac, hmacKey;
+
+        /**
+         * Looks up a cipher or hmac by name.  When it does not exist,
+         * this throws an exception.
+         *
+         * @param {number} code
+         * @param {Object} obj
+         * @param {string} humanReadable What we're seeking
+         * @return {*} obj[name]
+         * @throws {Error} when [name] does not exist on object
+         */
+        function lookup(code, obj, humanReadable) {
+            if (!obj[code]) {
+                throw new Error(`Invalid ${humanReadable} code: ${code}`);
+            }
+
+            return obj[code];
+        }
+
+        // Lookup algorithm definitions
+        hmac = lookup(header.hmacAlgoCode, ciphersAndHashes.hashesByCode, "HMAC Algorithm");
+        hmacKey = lookup(header.hmacKeyDigest, ciphersAndHashes.hashesByCode, "HMAC Key Digest");
+        cipher = lookup(header.cipherAlgoCode, ciphersAndHashes.ciphersByCode, "Cipher Algorithm");
+        cipherKey = lookup(header.cipherKeyDigest, ciphersAndHashes.hashesByCode, "Cipher Key Digest");
+
+        return buildParameters(hmac, hmacKey, header.hmacKeyIterations, cipher, cipherKey, header.cipherKeyIterations);
+    }
+
+
+    /**
+     * Decrypts data
+     *
+     * @param {(Buffer|string)} data
+     * @param {(Buffer|string)} keySource
+     * @return {Promise.<Buffer>}
+     */
+    function decryptAsync(data, keySource) {
+        if (typeof data === "string") {
+            data = new Buffer(data, "binary");
+        }
+
+        if (typeof keySource === "string") {
+            keySource = new Buffer(keySource, "binary");
+        }
+
+        return readHeaderAsync(data).then((header) => {
+            var parameters, posEncrypted, posEnd, posHmac, posIv;
+
+            parameters = parametersFromHeader(header);
+
+            // Assign position variables to the first byte of that spot
+            posHmac = header.headerLength;
+            posIv = posHmac + parameters.hmac.hmacBytes;
+            posEncrypted = posIv + parameters.cipher.ivBytes;
+            posEnd = posEncrypted + header.encryptedDataLength;
+
+            return promise.props({
+                cipherKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.cipherKey.iterations, parameters.cipherKey.bytes, parameters.cipherKey.name),
+                hmacKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.hmacKey.iterations, parameters.hmacKey.bytes, parameters.hmacKey.name)
+            }).then((bits) => {
+                var decipher, encrypted, hmac, hmacDigest, hmacExpected, iv;
+
+                // Extract the embedded record fields
+                hmacExpected = data.slice(posHmac, posIv);
+                iv = data.slice(posIv, posEncrypted);
+                encrypted = data.slice(posEncrypted, posEnd);
+
+                // Create a new HMAC object
+                hmac = crypto.createHmac(parameters.hmac.name, bits.hmacKey);
+
+                // Add the record header, iv and the encrypted message
+                hmac.update(data.slice(0, posHmac));
+                hmac.update(iv);
+                hmac.update(encrypted);
+                hmacDigest = hmac.digest();
+
+                // Double check - NOTE: the result of 0 means they are the same
+                if (Buffer.compare(hmacExpected, hmacDigest)) {
+                    throw new Error("HMAC invalid");
+                }
+
+                decipher = crypto.createDecipheriv(parameters.cipher.name, bits.cipherKey, iv);
+
+                return Buffer.concat([
+                    decipher.update(encrypted),
+                    decipher.final()
+                ]);
+            });
+        });
+    }
+
+
+    /**
+     * Generate a buffer describing the encryption record.
+     *
+     * @param {encryption~parameters} parameters
+     * @param {number} encryptedDataLength
+     * @return {Buffer}
+     */
+    function encryptionHeader(parameters, encryptedDataLength) {
+        var buff;
+
+        buff = new Buffer(17);
+
+        // Version
+        buff[0] = 0;
+        buff[1] = parameters.hmac.code;
+        buff[2] = parameters.hmacKey.code;
+        buff.writeUInt32LE(parameters.hmacKey.iterations, 3);
+        buff[7] = parameters.cipher.code;
+        buff[8] = parameters.cipherKey.code;
+        buff.writeUInt32LE(parameters.cipherKey.iterations, 9);
+        buff.writeUInt32LE(encryptedDataLength, 13);
+
+        return buff;
+    }
+
+
+    /**
+     * Looks up encryption-related objects.  This creates an object with
+     * all of the necessary settings to generate headers and perform the
+     * encryption / decryption.
+     *
+     * @param {encryption~methodConfig} hmacConfig
+     * @param {encryption~methodConfig} cipherConfig
+     * @return {Promise.<encryption~parameters>}
+     */
+    function parametersFromConfigAsync(hmacConfig, cipherConfig) {
+        return promise.try(() => {
+            var cipher, cipherKey, hmac, hmacKey;
+
+            /**
+             * Looks up a cipher or hmac by name.  When it does not exist,
+             * this throws an exception.
+             *
+             * @param {string} name
+             * @param {Object} obj
+             * @param {string} humanReadable What we're seeking
+             * @return {*} obj[name]
+             * @throws Error when [name] does not exist on object
+             */
+            function lookup(name, obj, humanReadable) {
+                if (!obj[name]) {
+                    throw new Error(`Invalid ${humanReadable} name: ${name}`);
+                }
+
+                return obj[name];
+            }
+
+            // Lookup algorithm definitions
+            hmac = lookup(hmacConfig.algorithm, ciphersAndHashes.hashes, "HMAC Algorithm");
+            hmacKey = lookup(hmacConfig.digest, ciphersAndHashes.hashes, "HMAC Key Digest");
+            cipher = lookup(cipherConfig.algorithm, ciphersAndHashes.ciphers, "Cipher Algorithm");
+            cipherKey = lookup(cipherConfig.digest, ciphersAndHashes.hashes, "Cipher Key Digest");
+
+            return buildParameters(hmac, hmacKey, hmacConfig.iterations, cipher, cipherKey, cipherConfig.iterations);
+        });
+    }
+
+
+    /**
+     * Builds a record that looks like this:
+     *
+     *   HEADER HMAC IV ENCRYPTED
+     *
+     * The HMAC validates a buffer that looks like this:
+     *
+     *   HEADER IV ENCRYPTED
+     *
+     * The header is first so we know the HMAC length, but we also want to
+     * hash the header to make sure the header was not modified.  Because
+     * of those conderns, it was decided to encode and process in the
+     * above described method.
+     *
+     * Zero byte salts are used because there is nowhere to store the salt
+     * safely that is separate from the keys that will be used for
+     * encryption and decryption.  Also, the generated keys are randomly
+     * generated, so we shouldn't need to worry about the strength here.
+     * The key derivation algorithm is mostly used to generate a key of the
+     * right length and to slow down attacks with the number of iterations.
+     *
+     * @param {(Buffer|string)} data
+     * @param {(Buffer|string)} keySource
+     * @param {encryption~methodConfig} hmacConfig
+     * @param {encryption~methodConfig} cipherConfig
+     * @return {Promise.<Buffer>}
+     */
+    function encryptAsync(data, keySource, hmacConfig, cipherConfig) {
+        if (typeof data === "string") {
+            data = new Buffer(data, "binary");
+        }
+
+        if (typeof keySource === "string") {
+            keySource = new Buffer(keySource, "binary");
+        }
+
+        return parametersFromConfigAsync(hmacConfig, cipherConfig).then((parameters) => {
+            return promise.props({
+                cipherKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.cipherKey.iterations, parameters.cipherKey.bytes, parameters.cipherKey.name),
+                iv: random.bufferAsync(parameters.cipher.ivBytes),
+                hmacKey: crypto.pbkdf2Async(keySource, new Buffer(0), parameters.hmacKey.iterations, parameters.hmacKey.bytes, parameters.hmacKey.name)
+            }).then((bits) => {
+                var bufferList, cipher, encryptedDataLength, hmac;
+
+                // Encrypt and store into the buffer.  Also add IV to buffer.
+                cipher = crypto.createCipheriv(parameters.cipher.name, bits.cipherKey, bits.iv);
+                bufferList = [
+                    // Header goes here
+                    null,
+
+                    // HMAC goes here
+                    null,
+                    bits.iv,
+                    cipher.update(data),
+                    cipher.final()
+                ];
+
+                // Attempt to destroy original data
+                data.fill(0);
+                encryptedDataLength = bufferList[3].length + bufferList[4].length;
+
+                // The header can now be created
+                bufferList[0] = encryptionHeader(parameters, encryptedDataLength);
+
+                // Create the secure hash and insert it into the buffer list
+                hmac = crypto.createHmac(parameters.hmac.name, bits.hmacKey);
+
+                // Header
+                hmac.update(bufferList[0]);
+
+                // IV
+                hmac.update(bufferList[2]);
+
+                // Some/most encrypted data
+                hmac.update(bufferList[3]);
+
+                // Remaining encrypted data
+                hmac.update(bufferList[4]);
+                bufferList[1] = hmac.digest();
+
+                return Buffer.concat(bufferList);
+            });
+        });
+    }
+
+
     // Wrap crypto in promises, but do not do this to all methods.
     // Wrapping individual functions prevents deprecation notices.
     crypto.pbkdf2Async = promise.promisify(crypto.pbkdf2);
 
     return {
-        decryptAsync: decryptAsync,
-        encryptAsync: encryptAsync
+        decryptAsync,
+        encryptAsync
     };
-}
+};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,3 @@
-/* eslint no-console:true */
-
 "use strict";
 
 module.exports = (config) => {
@@ -7,9 +5,9 @@ module.exports = (config) => {
         /**
          * Displays a message to the console only.
          *
-         * @param {*} ...data All parameters are sent to console.log.
+         * @param {*} data All parameters are sent to console.log.
          */
-        console: function () {
+        console() {
             var args;
 
             args = [].slice.call(arguments);
@@ -24,9 +22,9 @@ module.exports = (config) => {
          *
          * @param {string} text
          */
-        debug: (text) => {
+        debug(text) {
             if (config.debug) {
-                console.error("DEBUG: " + text);
+                console.error(`DEBUG: ${text}`);
             }
         },
 
@@ -36,8 +34,8 @@ module.exports = (config) => {
          *
          * @param {string} text
          */
-        error: (text) => {
-            console.error("ERROR: " + text);
+        error(text) {
+            console.error(`ERROR: ${text}`);
         },
 
 
@@ -46,7 +44,7 @@ module.exports = (config) => {
          *
          * @param {string} text
          */
-        info: (text) => {
+        info(text) {
             console.log(text);
         },
 
@@ -56,8 +54,8 @@ module.exports = (config) => {
          *
          * @param {string} text
          */
-        warn: (text) => {
-            console.error("WARN: " + text);
+        warn(text) {
+            console.error(`WARN: ${text}`);
         }
     };
 };

--- a/lib/mfa/hotp.js
+++ b/lib/mfa/hotp.js
@@ -7,6 +7,11 @@
  * We want to promisfy all methods we can because some of them
  * take some time to generate and we don't want code going on
  * till we have the data we need back.
+ *
+ * @param {Object} config
+ * @param {Object} twofa
+ * @param {Object} promise
+ * @return {Function} factory
  */
 module.exports = function (config, twofa, promise) {
     var twofaLocal;
@@ -70,8 +75,8 @@ module.exports = function (config, twofa, promise) {
     }
 
     return {
-        generateSecretAsync: generateSecretAsync,
-        generateQrCodeAsync: generateQrCodeAsync,
-        verifyToken: verifyToken
+        generateSecretAsync,
+        generateQrCodeAsync,
+        verifyToken
     };
 };

--- a/lib/middleware-profiler.js
+++ b/lib/middleware-profiler.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {Array.<number>} middlewareProfiler~hrtime
+ */
+
 module.exports = function (setIntervalFn) {
     /**
      * Monkey patches a server to enable profiling of middleware.  Does not
@@ -11,6 +15,9 @@ module.exports = function (setIntervalFn) {
      * @return {Function}
      */
     class MiddlewareProfiler {
+        /**
+         * Build the profiler
+         */
         constructor() {
             this.profiles = {};
         }
@@ -21,6 +28,7 @@ module.exports = function (setIntervalFn) {
          *
          * @param {Function} callback
          * @param {number} interval
+         * @return {*} interval identifier
          */
         displayAtInterval(callback, interval) {
             return setIntervalFn(() => {
@@ -47,39 +55,58 @@ module.exports = function (setIntervalFn) {
          * in a timing function.
          *
          * @param {Restify} server
-         * @param {Function}
          */
         profileServer(server) {
             var original, profiles;
 
             original = server.use;
-            profiles = this.profiles;  // Copy to access in next function
+
+            // Copy to local variable to access it in the next function
+            profiles = this.profiles;
 
             /**
              * This is the patched `use` method.  It's context is the server
              * object, not middlewareProfiler.
              *
-             * @param {String} [route]
+             * @param {string} [route]
              * @param {Function} fn
              * @return {*} Whatever the original `use()` returns.
              */
             server.use = function (route, fn) {
                 var args, cumulative, logName;
 
+                /**
+                 * Adds a bit more time to the cumulative time.
+                 *
+                 * @param {middlewareProfiler~hrtime} startTime
+                 * @param {middlewareProfiler~hrtime} endTime
+                 */
                 function addElapsed(startTime, endTime) {
                     var elapsed;
 
-                    elapsed = (endTime[0] - startTime[0]) + (endTime[1] - startTime[1]) / 1000000000;
+                    elapsed = endTime[0] - startTime[0] + (endTime[1] - startTime[1]) / 1000000000;
                     cumulative.elapsed += elapsed;
                     cumulative.hits += 1;
                 }
 
+                /**
+                 * Replaces the "next" or "done" callback.  Starts the timer
+                 * and calls a function.  When it is done, stops the timer
+                 * and continues execution.
+                 *
+                 * @param {Object} req Request
+                 * @param {Object} res Response
+                 * @param {Function} next
+                 * @return {*} Whatever is returned from the real middleware
+                 */
                 function finished(req, res, next) {
                     var startTime;
 
                     startTime = process.hrtime();
-                    return fn.call(this, req, res, function (val) {
+
+                    return fn(req, res, (val) => {
                         addElapsed(startTime, process.hrtime());
+
                         return next(val);
                     });
                 }
@@ -110,14 +137,14 @@ module.exports = function (setIntervalFn) {
                 };
 
                 return original.apply(this, args);
-            }
+            };
         }
 
 
         /**
          * Converts stats to a textual representation
          *
-         * @return {String}
+         * @return {string}
          */
         toString() {
             var lines;
@@ -126,9 +153,9 @@ module.exports = function (setIntervalFn) {
             Object.keys(this.profiles).forEach((name) => {
                 lines.push([
                     name,
-                    this.profiles[name].hits + " hits",
-                    Math.round(this.profiles[name].elapsed * 1000) + " ms",
-                    Math.round(1000 * this.profiles[name].elapsed / this.profiles[name].hits) + " avg"
+                    `${this.profiles[name].hits} hits`,
+                    `${Math.round(this.profiles[name].elapsed * 1000)} ms`,
+                    `${Math.round(1000 * this.profiles[name].elapsed / this.profiles[name].hits)} avg`
                 ].join(", "));
             });
 
@@ -137,4 +164,4 @@ module.exports = function (setIntervalFn) {
     }
 
     return MiddlewareProfiler;
-}
+};

--- a/lib/ot-date.js
+++ b/lib/ot-date.js
@@ -26,18 +26,21 @@
  * Factory to generate the OtDate object.
  *
  * @param {Object} moment
- * @return OtDate
+ * @return {OtDate}
  */
 module.exports = function (moment) {
     /**
      * Open Token Date Class to provide simple date functionality
      * using Moment.js. This always uses dates and times in UTC.
-     *
-     * @param {Moment} m
      */
     class OtDate {
+        /**
+         * Creates an instance of OtDate.
+         *
+         * @param {Moment} m
+         */
         constructor(m) {
-            if (! (m instanceof moment)) {
+            if (!(m instanceof moment)) {
                 throw new Error("Use helper functions instead");
             }
 
@@ -87,7 +90,6 @@ module.exports = function (moment) {
          * @return {Buffer}
          */
         toBuffer(b, offset) {
-
             if (!b) {
                 offset = 0;
                 b = new Buffer(4);

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,6 +1,11 @@
 "use strict";
 
 module.exports = function (bluebird) {
+    var Bluebird;
+
+    // This is done for the linter to be happier.
+    Bluebird = bluebird;
+
     return {
         /**
          * Returns a promise when all promises passed in are resolved.
@@ -26,8 +31,8 @@ module.exports = function (bluebird) {
          * @param {Function} callback(resolve, reject)
          * @return {Promise}
          */
-        create: function (callback) {
-            return new bluebird(callback);
+        create(callback) {
+            return new Bluebird(callback);
         },
 
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * Random data generation
  *
@@ -8,7 +10,7 @@
  * @param {Object} promise
  * @return {Object}
  */
-module.exports = function (base64, crypto, promise) {
+module.exports = (base64, crypto, promise) => {
     crypto.randomBytesAsync = promise.promisify(crypto.randomBytes);
 
     return {
@@ -34,9 +36,7 @@ module.exports = function (base64, crypto, promise) {
         randomIdAsync: (size) => {
             var binarySize;
 
-            binarySize = size / 4;
-            binarySize = Math.ceil(binarySize);
-            binarySize = binarySize * 3;
+            binarySize = 3 * Math.ceil(size / 4);
 
             return crypto.randomBytesAsync(binarySize).then((binaryBuffer) => {
                 var result;
@@ -48,5 +48,5 @@ module.exports = function (base64, crypto, promise) {
                 return result;
             });
         }
-    }
-}
+    };
+};

--- a/lib/record.js
+++ b/lib/record.js
@@ -16,6 +16,7 @@
  * @typedef {Object} record~options
  * @property {OtDate} expires Desired expiration date
  */
+
 module.exports = (bufferSerializer, config, encryption, fs, otDate, promise, zlib) => {
     var encryptionKeyBufferPromise;
 
@@ -50,7 +51,7 @@ module.exports = (bufferSerializer, config, encryption, fs, otDate, promise, zli
 
             buffer = bufferSerializer.toBuffer({
                 data: bits.encryptedOnce,
-                expires: expires
+                expires
             });
 
             return encryption.encryptAsync(buffer, bits.outerKey, config.encryption.primary.hmac, config.encryption.primary.cipher);
@@ -90,11 +91,11 @@ module.exports = (bufferSerializer, config, encryption, fs, otDate, promise, zli
     fs = promise.promisifyAll(fs);
     zlib = promise.promisifyAll(zlib);
 
-    // TODO: Move this to an async config validation module
+    // Move this to an async config validation module
     encryptionKeyBufferPromise = fs.readFileAsync(config.record.encryptionKeyFile, "binary");
 
     return {
-        freezeAsync: freezeAsync,
-        thawAsync: thawAsync
+        freezeAsync,
+        thawAsync
     };
 };

--- a/lib/rest-middleware.js
+++ b/lib/rest-middleware.js
@@ -1,8 +1,16 @@
+/* eslint new-cap:0 */
+"use strict";
+
+/**
+ * This function is a class
+ */
+
 module.exports = function (helmet, logger, restify, restifyLinks) {
     /**
      * Chains middleware from Helmet and other sources.
      *
      * @param {Object} config
+     * @param {Object} server
      * @return {Function} useMiddleware
      */
     return (config, server) => {
@@ -17,13 +25,16 @@ module.exports = function (helmet, logger, restify, restifyLinks) {
             res.links({
                 self: config.baseUrl + req.href(),
                 up: {
-                    href: config.baseUrl + "/",
+                    href: `${config.baseUrl}/`,
                     title: "self-discovery"
                 }
             });
             next();
         }
 
+        /**
+         * Adds middleware to the server
+         */
         function useMiddleware() {
             logger.debug("Adding Middleware in restMiddleware");
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,4 +1,5 @@
 "use strict";
+
 /**
  * Manages the schemas we have loaded and validation for checking
  * data against those schemas.
@@ -15,8 +16,9 @@
  * @property {Array.<Object>} errors
  * @property {Array.<string>} missing
  */
+
 module.exports = (fs, glob, promise, tv4, validator) => {
-    var schemasLoaded, globAsync;
+    var globAsync, schemasLoaded;
 
     schemasLoaded = {};
     fs.readFileAsync = promise.promisify(fs.readFile);
@@ -54,18 +56,18 @@ module.exports = (fs, glob, promise, tv4, validator) => {
         return fs.readFileAsync(schema).then((contents) => {
             return JSON.parse(contents.toString("utf-8"));
         }).then(null, () => {
-            throw new Error("Unable to parse file: " + schema);
+            throw new Error(`Unable to parse file: ${schema}`);
         }).then((schemaObject) => {
             var id;
 
             id = schema.replace(relativeTo, "").replace(/\.json$/, "");
 
-            if (id.charAt(0) != "/") {
-                id = "/" + id;
+            if (id.charAt(0) !== "/") {
+                id = `/${id}`;
             }
 
             if (schemaObject.id && schemaObject.id !== id) {
-                throw new Error("Schema had wrong ID: " + schema + " should have the id " + id);
+                throw new Error(`Schema had wrong ID: ${schema} should have the id ${id}`);
             }
 
             schemaObject.id = id;
@@ -83,7 +85,7 @@ module.exports = (fs, glob, promise, tv4, validator) => {
      * @return {Promise.<*>}
      */
     function loadSchemaFolderAsync(path) {
-        return globAsync(path + "**/*.json", {
+        return globAsync(`${path}**/*.json`, {
             strict: true,
             nodir: true
         }).then((files) => {
@@ -105,8 +107,8 @@ module.exports = (fs, glob, promise, tv4, validator) => {
     function validate(data, schema) {
         var result;
 
-        if (! schemasLoaded[schema]) {
-            throw new Error("Schema is not loaded: " + schema);
+        if (!schemasLoaded[schema]) {
+            throw new Error(`Schema is not loaded: ${schema}`);
         }
 
         result = tv4.validateResult(data, schema);
@@ -119,9 +121,9 @@ module.exports = (fs, glob, promise, tv4, validator) => {
     }
 
     return {
-        getMissingSchemas: getMissingSchemas,
-        loadSchemaAsync: loadSchemaAsync,
-        loadSchemaFolderAsync: loadSchemaFolderAsync,
-        validate: validate
+        getMissingSchemas,
+        loadSchemaAsync,
+        loadSchemaFolderAsync,
+        validate
     };
 };

--- a/lib/secure-hash.js
+++ b/lib/secure-hash.js
@@ -1,4 +1,11 @@
+/* eslint no-bitwise:0 */
 "use strict";
+
+/**
+ * Handles the hashing of data in a secure fashion for use
+ * where needed.
+ */
+
 /**
  * The configuration object for hashing sets up a personal
  * way of hashing data. Each parameter is optional,
@@ -11,10 +18,6 @@
  * @property {string} salt should be rather lengthy
  */
 
-/**
- * Handles the hashing of data in a secure fashion for use
- * where needed.
- */
 module.exports = function (base64, crypto, promise) {
     crypto.pbkdf2Async = promise.promisify(crypto.pbkdf2);
 
@@ -41,7 +44,7 @@ module.exports = function (base64, crypto, promise) {
             differences += dataHashed[i] ^ compareTo[i];
         }
 
-        return differences == 0;
+        return differences === 0;
     }
 
 
@@ -56,7 +59,7 @@ module.exports = function (base64, crypto, promise) {
     function secureHashAsync(data, config) {
         var algorithm, hashLength, iterations, salt;
 
-        if (! data) {
+        if (!data) {
             throw new Error("Nothing to hash");
         }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -10,9 +10,9 @@ module.exports = function (config, container) {
     engine = config.storage.engine;
 
     try {
-        classFactory = require("./storage/" + engine);
+        classFactory = require(`./storage/${engine}`);
     } catch (error) {
-        throw new Error("Could not find Storage Engine: " + config.storage.engine);
+        throw new Error(`Could not find Storage Engine: ${config.storage.engine}`);
     }
 
     return container.call(classFactory);

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -5,7 +5,7 @@
  * Amazon S3. We explicitly say how we are communicating
  * and what functions are open to use.
  *
- * All methods are asychronous.
+ * All methods are asynchronous.
  */
 
 /**
@@ -30,20 +30,37 @@
 module.exports = function (awsSdk, config, promise) {
     var awsS3, s3Bucket;
 
-    awsS3 = null;
-    s3Bucket = null;
-    configure(config.storage.s3);
-
     /**
      * Configures options for AWS.
      *
-     * @param {s3~configOptions} config
+     * @param {s3~configOptions} incomingConfig
      */
-    function configure(config) {
-        awsSdk.config.region = config.region;
-        s3Bucket = config.bucket;
+    function configure(incomingConfig) {
+        awsSdk.config.region = incomingConfig.region;
+        s3Bucket = incomingConfig.bucket;
     }
 
+
+    /**
+     * Creates the S3 bucket we need for subsequent calls.
+     * Not normally used outside the class, but exposed for
+     * testing.
+     *
+     * @return {Object} awsS3
+     */
+    function transit() {
+        if (!awsS3) {
+            awsS3 = new awsSdk.S3({
+                params: {
+                    Bucket: s3Bucket
+                }
+            });
+
+            awsS3 = promise.promisifyAll(awsS3);
+        }
+
+        return awsS3;
+    }
 
     /**
      * Deletes a single file from configured bucket.
@@ -134,32 +151,15 @@ module.exports = function (awsSdk, config, promise) {
     }
 
 
-    /**
-     * Creates the S3 bucket we need for subsequent calls.
-     * Not normally used outside the class, but exposed for
-     * testing.
-     *
-     * @return {Object} awsS3
-     */
-    function transit() {
-        if (! awsS3) {
-            awsS3 = new awsSdk.S3({
-                params: {
-                    Bucket: s3Bucket
-                }
-            });
-
-            awsS3 = promise.promisifyAll(awsS3);
-        }
-
-        return awsS3;
-    }
+    awsS3 = null;
+    s3Bucket = null;
+    configure(config.storage.s3);
 
     return {
-        delAsync: delAsync,
-        getAsync: getAsync,
-        listAsync: listAsync,
-        putAsync: putAsync,
-        transit: transit
+        delAsync,
+        getAsync,
+        listAsync,
+        putAsync,
+        transit
     };
 };

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -3,9 +3,19 @@
 module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRouterMagic, restMiddleware) => {
     restifyRouterMagic = promise.promisify(restifyRouterMagic);
 
+    /**
+     * A configured web server, able to serve files from a configurable route
+     * folder.
+     */
     class WebServer {
+        /**
+         * Creates a WebServer object.
+         *
+         * @param {Object} config Used to configure how the web server works
+         */
         constructor(config) {
-            this.configure(config);  // Sets this.config, this.restifyConfig
+            // Sets this.config, this.restifyConfig
+            this.configure(config);
             this.serverContracts = [];
         }
 
@@ -32,15 +42,19 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
         addMiddleware(a, b) {
             if (arguments.length > 1) {
                 this.addContract((server) => {
-                    logger.debug("Adding middleware for route: " + a);
-                    server.use(a, b);  // path and callback
+                    logger.debug(`Adding middleware for route: ${a}`);
+
+                    // a is path, b is callback
+                    server.use(a, b);
 
                     return server;
                 });
             } else {
                 this.addContract((server) => {
                     logger.debug("Adding middleware");
-                    server.use(a);  // a = callback
+
+                    // a is callback
+                    server.use(a);
 
                     return server;
                 });
@@ -59,7 +73,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
         addRoutes(routesPath) {
             this.addContract((server) => {
                 return restifyRouterMagic(server, {
-                    routesPath: routesPath
+                    routesPath
                 }).then(() => {
                     return server;
                 });
@@ -78,7 +92,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
         app() {
             var promiseResult;
 
-            logger.debug("Creating server with config: " + JSON.stringify(this.config));
+            logger.debug(`Creating server with config: ${JSON.stringify(this.config)}`);
 
             if (this.config.https) {
                 promiseResult = promise.all([
@@ -112,7 +126,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
         attachErrorHandlers() {
             return (server) => {
                 server.on("uncaughtException", (req, res, route, error) => {
-                    logger.error("Uncaught Exception: " + error.toString());
+                    logger.error(`Uncaught Exception: ${error.toString()}`);
                     logger.console("Uncaught Exception:", error);
 
                     res.send(500);
@@ -136,40 +150,45 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
 
             // All values go in here and are converted to the right data types
             this.config = {
-                baseUrl: config.baseUrl || "",
-                certificateFile: config.certificateFile,  // HTTPS CA Chain and certificate
-                keyFile: config.keyFile, // HTTPS private key
-                https: true,
-                name: config.name || "OpenToken API",  // For Server Name fields
-                port: +(config.port || 8080), // For listening
+                baseUrl: config.baseUrl || "/",
+
+                // HTTPS CA Chain and certificate
+                certificateFile: config.certificateFile,
+
+                // HTTPS private key
+                keyFile: config.keyFile,
+                https: config.certificateFile && config.keyFile,
+
+                // For "Server Name" fields
+                name: config.name || "OpenToken API",
+
+                // Port for listening
+                port: +(config.port || 8080),
                 profileMiddleware: !!config.profileMiddleware,
-                proxyProtocol: config.proxyProtocol || false,  // boolean or object
-                spdy: config.spdy || null,  // Options for node-spdy
-                version: config.version || null  // For routes
+
+                // Boolean or object
+                proxyProtocol: config.proxyProtocol || false,
+
+                // Options for node-spdy
+                spdy: config.spdy || null
             };
-            config = null;  // For safety - don't use this object any longer
 
-            // Make sure our baseUrl does not end with a slash
-            if (this.config.baseUrl.substr(-1) === "/") {
-                this.config.baseUrl = this.config.baseUrl.substr(0, this.config.baseUrl.length - 1);
-            }
-
-            // Error checking HTTPS options
-            if (!this.config.certificateFile || !this.config.keyFile) {
-                this.config.certificateFile = null;
-                this.config.keyFile = null;
-                this.config.https = false;
-            }
+            // For safety, we don't use the original object any longer.
+            config = null;
 
             // Select values are plucked into this one
             this.restifyConfig = {
-                handleUncaughtExceptions: true, // Turning on uncaughtException handling
-                handleUpgrades: false,  // Intentionally do not upgrade the connection
-                httpsServerOptions: null,  // Could construct this object instead
+                // Turning on uncaughtException handling
+                handleUncaughtExceptions: true,
+
+                // Intentionally do not upgrade the connection
+                handleUpgrades: false,
+
+                // Could construct this object instead
+                httpsServerOptions: null,
                 name: this.config.name,
                 proxyProtocol: this.config.proxyProtocol,
-                spdy: this.config.spdy,
-                version: this.config.version
+                spdy: this.config.spdy
             };
 
             return this;
@@ -189,7 +208,7 @@ module.exports = (fs, logger, MiddlewareProfiler, promise, restify, restifyRoute
                 return promise.fromCallback((callback) => {
                     server.listen(port, callback);
                 }).then(() => {
-                    logger.info("Server listening on port " + port);
+                    logger.info(`Server listening on port ${port}`);
 
                     return server;
                 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "lib/opentoken.js",
     "scripts": {
         "start": "node bin/server.js || true",
-        "test": "istanbul cover jasmine-node --captureExceptions spec/ && codecov",
+        "test": "istanbul cover jasmine-node --captureExceptions spec/ && codecov && eslint .",
         "watch": "jasmine-node lib spec --autotest --watch"
     },
     "repository": {
@@ -34,6 +34,7 @@
     "homepage": "https://github.com/opentoken-io/opentoken#readme",
     "devDependencies": {
         "codecov": "^1.0.1",
+        "eslint": "^2.10.2",
         "istanbul": "^0.4.2",
         "jasmine-node": "^1.14.5"
     },

--- a/route/index.js
+++ b/route/index.js
@@ -2,9 +2,9 @@
 
 module.exports = () => {
     return {
-        get: function (req, res, next) {
+        get(req, res, next) {
             res.setHeader("Content-Type", "text/plain");
-            res.send("API running " + (new Date()) + "\n");
+            res.send(`API running ${new Date()}\n`);
             next();
         }
     };

--- a/schema/config/server.json
+++ b/schema/config/server.json
@@ -6,6 +6,14 @@
             "minLength": 2,
             "pattern": "/$"
         },
+        "certificateFile": {
+            "type": "string",
+            "minLength": 1
+        },
+        "keyFile": {
+            "type": "string",
+            "minLength": 1
+        },
         "name": {
             "type": "string",
             "minLength": 1
@@ -19,7 +27,40 @@
             "type": "boolean"
         },
         "proxyProtocol": {
-            "type": "boolean"
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "spdy": {
+            "type": "object"
         }
-    }
+    },
+    "allOf": [
+        {
+            "description": "Define both certificateFile and keyFile or neither",
+            "oneOf": [
+                {
+                    "required": [
+                        "certificatFile",
+                        "keyFile"
+                    ]
+                },
+                {
+                    "properties": {
+                        "certificateFile": {
+                            "type": "null"
+                        },
+                        "keyFile": {
+                            "type": "null"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/spec/helper/fail.helper.js
+++ b/spec/helper/fail.helper.js
@@ -1,4 +1,6 @@
-if (! jasmine.fail) {
+"use strict";
+
+if (!jasmine.fail) {
     /**
      * Sets up the scenario to actually fail; `actual` and `expected`
      * need to never match.

--- a/spec/helper/test-promise-failure.helper.js
+++ b/spec/helper/test-promise-failure.helper.js
@@ -1,9 +1,12 @@
+"use strict";
+
 /**
- * This allows testing of a promise which is intented to fail.
+ * This allows testing of a promise which is intended to fail.
  *
  * @param {Promise} promise
  * @param {string} errMessage
  * @param {Function} done
+ * @return {Promise}
  */
 jasmine.testPromiseFailure = function (promise, errMessage, done) {
     if (typeof errMessage === "function") {
@@ -11,9 +14,9 @@ jasmine.testPromiseFailure = function (promise, errMessage, done) {
         errMessage = null;
     }
 
-    return promise.then(function () {
+    return promise.then(() => {
         done(new Error("The promise should have been rejected"));
-    }, function (err) {
+    }, (err) => {
         if (errMessage) {
             expect(err.toString()).toContain(errMessage);
         }

--- a/spec/lib/account/account-manager.spec.js
+++ b/spec/lib/account/account-manager.spec.js
@@ -13,7 +13,7 @@ describe("AccountManager", () => {
         ]);
         accountServiceFake.completeAsync.andCallFake((accountInfo) => {
             return promiseMock.resolve({
-                accountId: accountInfo. accountId
+                accountId: accountInfo.accountId
             });
         });
         accountServiceFake.getRegistrationFileAsync.andCallFake(() => {
@@ -25,7 +25,7 @@ describe("AccountManager", () => {
         });
         accountServiceFake.signupInitiateAsync.andCallFake((accountInfo, options, regId) => {
             return promiseMock.resolve({
-                regId: regId
+                regId
             });
         });
         hotpFake = jasmine.createSpyObj("hotpFake", [
@@ -67,6 +67,7 @@ describe("AccountManager", () => {
                 email: "some.one@example.net"
             }).then((result) => {
                 var args;
+
                 expect(result.regId.length).toBe(128);
                 args = accountServiceFake.signupInitiateAsync.mostRecentCall.args;
                 expect(args[0].passwordSalt.length).toBe(256);

--- a/spec/lib/account/account-service.spec.js
+++ b/spec/lib/account/account-service.spec.js
@@ -33,9 +33,9 @@ describe("AccountService", () => {
     });
     describe(".completeAsync()", () => {
         it("puts the information successfully", (done) => {
-            accountService.getRegistrationFileAsync = jasmine.createSpy().andCallFake((directory) => {
+            accountService.getRegistrationFileAsync = jasmine.createSpy().andCallFake(() => {
                 return promiseMock.resolve(
-                    new Buffer('{"data": "thing"}', "binary")
+                    new Buffer("{\"data\": \"thing\"}", "binary")
                 );
             });
             accountService.completeAsync({
@@ -63,19 +63,24 @@ describe("AccountService", () => {
                 });
             }).then(done, done);
         });
-        it ("gets a registration file without config options", (done) => {
+        it("gets a registration file without config options", (done) => {
             var accountServiceLocal;
 
             accountServiceLocal = require("../../../lib/account/account-service")({}, secureHash, storageMock);
             accountServiceLocal.getRegistrationFileAsync("regIdUnhashed").then((result) => {
+                var args;
+
                 expect(result).toEqual({
                     data: "thing"
                 });
-                expect(secureHash.hashAsync).toHaveBeenCalledWith("regIdUnhashed", undefined);
+                expect(secureHash.hashAsync).toHaveBeenCalled();
+                args = secureHash.hashAsync.mostRecentCall.args;
+                expect(args[0]).toBe("regIdUnhashed");
+                expect(typeof args[1]).toBe("undefined");
             }).then(done, done);
         });
     });
-    describe(".signupInitiateAsync()", (done) => {
+    describe(".signupInitiateAsync()", () => {
         it("gets the registration id", (done) => {
             accountService.signupInitiateAsync({
                 email: "some.one@example.net",

--- a/spec/lib/api-server.spec.js
+++ b/spec/lib/api-server.spec.js
@@ -12,8 +12,8 @@ describe("ApiServer", () => {
 
         config = {
             server: {
-                "baseUrl": "https://localhost:8080/",
-                "port": 8443
+                baseUrl: "https://localhost:8080/",
+                port: 8443
             }
         };
         apiServer = apiServerFactory(config, WebServerMock);

--- a/spec/lib/base64.spec.js
+++ b/spec/lib/base64.spec.js
@@ -33,26 +33,26 @@ describe("base64", () => {
             name: "DEAD BEEF"
         }
     ].forEach((scenario) => {
-        it("encodes a string to a string: " + scenario.name, () => {
+        it(`encodes a string to a string: ${scenario.name}`, () => {
             var result;
 
             result = base64.encode(scenario.decoded);
             expect(result).toEqual(scenario.encoded);
         });
-        it("encodes a buffer to a buffer: " + scenario.name, () => {
+        it(`encodes a buffer to a buffer: ${scenario.name}`, () => {
             var result;
 
             result = base64.encode(new Buffer(scenario.decoded, "binary"));
             expect(result).toEqual(jasmine.any(Buffer));
             expect(result.toString("binary")).toEqual(scenario.encoded);
         });
-        it("decodes a string from a string" + scenario.name, () => {
+        it(`decodes a string from a string: ${scenario.name}`, () => {
             var result;
 
             result = base64.decode(scenario.encoded);
             expect(result).toEqual(scenario.decoded);
         });
-        it("decodes a buffer from a buffer " + scenario.name, () => {
+        it(`decodes a buffer from a buffer: ${scenario.name}`, () => {
             var result;
 
             result = base64.decode(new Buffer(scenario.encoded, "binary"));

--- a/spec/lib/bootstrap.spec.js
+++ b/spec/lib/bootstrap.spec.js
@@ -1,0 +1,60 @@
+"use strict";
+
+describe("bootstrap", () => {
+    var baseDir, bootstrap, config, schemaMock;
+
+    beforeEach(() => {
+        var path, promise;
+
+        baseDir = __dirname.replace(/\/spec(\/.*)?$/, "/");
+        config = require("../../config.json");
+        path = require("path");
+        promise = require("../mock/promise-mock");
+        schemaMock = jasmine.createSpyObj("schema", [
+            "getMissingSchemas",
+            "loadSchemaFolderAsync",
+            "validate"
+        ]);
+        schemaMock.getMissingSchemas.andReturn([]);
+        bootstrap = () => {
+            var real;
+
+            real = require("../../lib/bootstrap")(config, path, promise, schemaMock);
+
+            return real(baseDir);
+        };
+    });
+    it("passes with stock config", (done) => {
+        bootstrap().then(() => {
+            expect(schemaMock.loadSchemaFolderAsync).toHaveBeenCalledWith(`${baseDir}schema/`);
+        }).then(done, done);
+    });
+    it("errors when config is a string", (done) => {
+        config = "test";
+        jasmine.testPromiseFailure(bootstrap(), "Configuration is not an object", done);
+    });
+    it("errors when config is null", (done) => {
+        config = null;
+        jasmine.testPromiseFailure(bootstrap(), "Configuration is not an object", done);
+    });
+    it("errors when schemaPath is undefined", (done) => {
+        config = {};
+        jasmine.testPromiseFailure(bootstrap(), "config.schemaPath is not set", done);
+    });
+    it("errors when there are missing schemas", (done) => {
+        schemaMock.getMissingSchemas.andReturn([
+            "/schema"
+        ]);
+        jasmine.testPromiseFailure(bootstrap(), "Unresolved schema references", done);
+    });
+    it("errors when the schema does not validate", (done) => {
+        schemaMock.validate.andReturn({
+            error: {
+                dataPath: "x/y",
+                message: "Oh noes!",
+                schemaPath: "x/y"
+            }
+        });
+        jasmine.testPromiseFailure(bootstrap(), "Config did not validate", done);
+    });
+});

--- a/spec/lib/buffer-serializer.spec.js
+++ b/spec/lib/buffer-serializer.spec.js
@@ -33,8 +33,8 @@ describe("bufferSerializer", () => {
         result = bufferSerializer.toBuffer(date);
         expect(result).toEqual(jasmine.any(Buffer));
 
-        //         Ver     Z   O t D a t e      T ..Date, no ms
-        expected = "00" + "5A064F7444617465" + "544F00F380";
+        //          V Z   O t D a t e T ..Date, no ms
+        expected = "005A064F7444617465544F00F380";
         expect(result.toString("hex").toUpperCase()).toEqual(expected);
     });
     it("deserializes OtDate", () => {

--- a/spec/lib/encryption.spec.js
+++ b/spec/lib/encryption.spec.js
@@ -1,3 +1,5 @@
+/* eslint no-bitwise:"off" */
+
 "use strict";
 
 describe("encryption", () => {
@@ -25,7 +27,7 @@ describe("encryption", () => {
         }).then((result) => {
             expect(result.toString("hex")).toEqual("0001053200000040031d0000000b00000053f8a825e3b1c5e9537c20800324153042424242424242424242424242424242e94cea7494417116671128");
         }).then(done, done);
-    })
+    });
     it("decrypts from a string with a key as a buffer", (done) => {
         // The rest of the tests use Buffers because it is WAY easier
         var asString;
@@ -57,7 +59,7 @@ describe("encryption", () => {
             plain = "as a string";
         });
         it("errors with invalid HMAC", (done) => {
-            buff[20] = buff[20] ^ 0xF;
+            buff[20] ^= 0xF;
             jasmine.testPromiseFailure(encryption.decryptAsync(buff, keySource), "HMAC invalid", done);
         });
         [
@@ -86,17 +88,17 @@ describe("encryption", () => {
                 text: "Cipher Key Digest"
             }
         ].forEach((scenario) => {
-            it("errors with invalid encoding parameters - " + scenario.text, (done) => {
+            it(`errors with invalid encoding parameters - ${scenario.text}`, (done) => {
                 var config;
 
                 config = {
-                    hmacConfig: hmacConfig,
-                    cipherConfig: cipherConfig
+                    hmacConfig,
+                    cipherConfig
                 };
                 config[scenario.config][scenario.property] = "invalid";
                 jasmine.testPromiseFailure(encryption.encryptAsync(plain, keySource, hmacConfig, cipherConfig), scenario.text, done);
             });
-            it("errors with invalid header config - " + scenario.text, (done) => {
+            it(`errors with invalid header config - ${scenario.text}`, (done) => {
                 buff[scenario.byte] = 0xFF;
                 jasmine.testPromiseFailure(encryption.decryptAsync(buff, keySource), scenario.text, done);
             });
@@ -120,12 +122,12 @@ describe("encryption", () => {
             plain: "abcdefg"
         }
     ].forEach((scenario) => {
-        it("encrypts in the latest version: " + scenario.name, (done) => {
+        it(`encrypts in the latest version: ${scenario.name}`, (done) => {
             encryption.encryptAsync(scenario.plain, scenario.keySource, scenario.hmacConfig, scenario.cipherConfig).then((result) => {
                 expect(result.toString("hex")).toEqual(scenario.encryptedHex);
             }).then(done, done);
         });
-        it("decrypts the latest version: " + scenario.name, (done) => {
+        it(`decrypts the latest version: ${scenario.name}`, (done) => {
             encryption.decryptAsync(new Buffer(scenario.encryptedHex, "hex"), scenario.keySource).then((result) => {
                 expect(result.toString("binary")).toEqual(scenario.plain);
             }).then(done, done);

--- a/spec/lib/middleware-profiler.spec.js
+++ b/spec/lib/middleware-profiler.spec.js
@@ -26,7 +26,7 @@ describe("MiddlewareProfiler", () => {
             expect(args.length).toBe(2);
             expect(args[1]).toBe(1234);
             expect(args[0]).toEqual(jasmine.any(Function));
-            expect(function () {
+            expect(() => {
                 args[0]();
             }).not.toThrow();
         });
@@ -58,6 +58,13 @@ describe("MiddlewareProfiler", () => {
             var args1, args2, middle1, middle2, wrap1;
 
             beforeEach(() => {
+                /**
+                 * Create fake middleware that simply consumes time
+                 *
+                 * @param {Object} req Request
+                 * @param {Object} res Response
+                 * @param {Function} next
+                 */
                 function fakeMiddleware(req, res, next) {
                     var i, start;
 
@@ -65,7 +72,7 @@ describe("MiddlewareProfiler", () => {
                     i = 0;
 
                     // A little delay and fake work
-                    while (start == (new Date())) {
+                    while (start === new Date()) {
                         i += 1;
                     }
 
@@ -100,7 +107,7 @@ describe("MiddlewareProfiler", () => {
                         hits: 0,
                         elapsed: 0
                     },
-                    "_": {
+                    _: {
                         hits: 0,
                         elapsed: 0
                     }
@@ -144,11 +151,11 @@ describe("MiddlewareProfiler", () => {
             var profiles;
 
             profiles = mp.getProfiles();
-            profiles["fake"] = {
+            profiles.fake = {
                 elapsed: 0,
                 hits: 0
             };
-            profiles["fake2"] = {
+            profiles.fake2 = {
                 elapsed: .3333,
                 hits: 3
             };

--- a/spec/lib/ot-date.spec.js
+++ b/spec/lib/ot-date.spec.js
@@ -1,15 +1,28 @@
 "use strict";
 
 describe("OtDate", () => {
-    var otDate;
+    var OtDate;
 
+    /**
+     * Compares a date against a string
+     *
+     * @param {Date} actual
+     * @param {string} expected
+     */
     function testDate(actual, expected) {
         expect(actual).toEqual(jasmine.any(Date));
         expect(actual.toISOString()).toEqual(expected);
     }
 
+
+    /**
+     * Compares an OtDate object against a string
+     *
+     * @param {OtDate} actual
+     * @param {string} expected
+     */
     function testOtDate(actual, expected) {
-        expect(actual).toEqual(jasmine.any(otDate));
+        expect(actual).toEqual(jasmine.any(OtDate));
         expect(actual.toString()).toEqual(expected);
     }
 
@@ -17,20 +30,20 @@ describe("OtDate", () => {
         var moment;
 
         moment = require("moment");
-        otDate = require("../../lib/ot-date")(moment);
+        OtDate = require("../../lib/ot-date")(moment);
     });
     describe("fromDate() & toDate()", () => {
         it("gets an OtDate object back from a custom date/time", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16"));
+            result = OtDate.fromDate(new Date("2016-04-16"));
             testOtDate(result, "2016-04-16T00:00:00.000Z");
             result = result.toDate();
             testDate(result, "2016-04-16T00:00:00.000Z");
         });
         it("throws an error for not getting passed a Date object", () => {
             expect(() => {
-                otDate.fromDate("2016-04-16");
+                OtDate.fromDate("2016-04-16");
             }).toThrow();
         });
     });
@@ -38,50 +51,50 @@ describe("OtDate", () => {
         it("gets an OtDate object back from a buffer after creating as a buffer", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16")).toBuffer();
+            result = OtDate.fromDate(new Date("2016-04-16")).toBuffer();
             expect(result).toEqual(jasmine.any(Buffer));
             expect(result.length).toBe(4);
-            testOtDate(otDate.fromBuffer(result), "2016-04-16T00:00:00.000Z");
+            testOtDate(OtDate.fromBuffer(result), "2016-04-16T00:00:00.000Z");
         });
         it("gets an OtDate object back from a buffer at 1", () => {
             var b;
 
             b = new Buffer(5);
-            otDate.fromDate(new Date("2016-04-16")).toBuffer(b, 1);
-            testOtDate(otDate.fromBuffer(b, 1), "2016-04-16T00:00:00.000Z");
+            OtDate.fromDate(new Date("2016-04-16")).toBuffer(b, 1);
+            testOtDate(OtDate.fromBuffer(b, 1), "2016-04-16T00:00:00.000Z");
         });
     });
     describe("fromString()", () => {
         it("passes in a date string", () => {
-            testOtDate(otDate.fromString("2016-04-16"), "2016-04-16T00:00:00.000Z");
+            testOtDate(OtDate.fromString("2016-04-16"), "2016-04-16T00:00:00.000Z");
         });
         it("passes in a date string with time", () => {
-            testOtDate(otDate.fromString("2016-04-16T03:00:00"), "2016-04-16T03:00:00.000Z");
+            testOtDate(OtDate.fromString("2016-04-16T03:00:00"), "2016-04-16T03:00:00.000Z");
         });
         it("passes in a date string with time and time zone converting to UTC", () => {
-            testOtDate(otDate.fromString("2016-04-16T03:00:00.000+0600"), "2016-04-15T21:00:00.000Z");
+            testOtDate(OtDate.fromString("2016-04-16T03:00:00.000+0600"), "2016-04-15T21:00:00.000Z");
         });
         it("throws an error for not getting passed a Date object", () => {
             expect(() => {
-                otDate.fromString(new Date("2016-04-16"));
+                OtDate.fromString(new Date("2016-04-16"));
             }).toThrow();
         });
     });
     describe("isBefore()", () => {
         it("checks the date is before the set date", () => {
-            expect(otDate.fromDate(new Date("2016-04-17")).isBefore("2016-04-16")).toEqual(false);
+            expect(OtDate.fromDate(new Date("2016-04-17")).isBefore("2016-04-16")).toEqual(false);
         });
         it("checks the date is after the set date", () => {
-            expect(otDate.fromDate(new Date("2016-04-17")).isBefore("2016-04-19")).toEqual(true);
+            expect(OtDate.fromDate(new Date("2016-04-17")).isBefore("2016-04-19")).toEqual(true);
         });
         it("checks the date is after the set date and is a Date object", () => {
-            expect(otDate.fromDate(new Date("2016-04-16")).isBefore(new Date("2016-04-16"))).toEqual(false);
+            expect(OtDate.fromDate(new Date("2016-04-16")).isBefore(new Date("2016-04-16"))).toEqual(false);
         });
         it("checks the date is after the set date and is an instance of OtDate", () => {
             var otherDate;
 
-            otherDate = otDate.fromString("2016-04-15");
-            expect(otDate.fromDate(new Date("2016-04-16")).isBefore(otherDate)).toEqual(false);
+            otherDate = OtDate.fromString("2016-04-15");
+            expect(OtDate.fromDate(new Date("2016-04-16")).isBefore(otherDate)).toEqual(false);
         });
     });
     describe("now()", () => {
@@ -89,7 +102,7 @@ describe("OtDate", () => {
             var afterTime, beforeTime, result;
 
             beforeTime = new Date();
-            result = otDate.now().toDate();
+            result = OtDate.now().toDate();
             afterTime = new Date();
 
             // Test that the result is between beforeTime and afterTime
@@ -101,7 +114,7 @@ describe("OtDate", () => {
         it("moves the current time to three hours ahead", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16 03:00:00Z")).plus({
+            result = OtDate.fromDate(new Date("2016-04-16 03:00:00Z")).plus({
                 hours: 3
             });
             testOtDate(result, "2016-04-16T06:00:00.000Z");
@@ -111,25 +124,28 @@ describe("OtDate", () => {
         it("gets the formatted date/time back as a string", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16")).toString();
+            result = OtDate.fromDate(new Date("2016-04-16")).toString();
             expect(result).toEqual("2016-04-16T00:00:00.000Z");
         });
         it("gets the UTC date/time when passing in a local date/time", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16T14:00:00.000+0600")).toString();
+            result = OtDate.fromDate(new Date("2016-04-16T14:00:00.000+0600")).toString();
             expect(result).toEqual("2016-04-16T08:00:00.000Z");
         });
         it("gets the UTC date/time when no timezone is set", () => {
             var result;
 
-            result = otDate.fromDate(new Date("2016-04-16T03:00:00.000")).toString();
+            result = OtDate.fromDate(new Date("2016-04-16T03:00:00.000")).toString();
             expect(result).toEqual("2016-04-16T03:00:00.000Z");
         });
     });
     it("throws an error when calling class directly", () => {
         expect(() => {
-            new otDate();
+            var otDate;
+
+            otDate = new OtDate();
+            otDate.toString();
         }).toThrow();
     });
 });

--- a/spec/lib/promise.spec.js
+++ b/spec/lib/promise.spec.js
@@ -16,6 +16,11 @@ describe("promise", () => {
     var promise;
 
     beforeEach(() => {
+        /**
+         * Fake Bluebird class
+         *
+         * @param {Function} callback
+         */
         function fakeBluebird(callback) {
             callback();
         }
@@ -26,14 +31,14 @@ describe("promise", () => {
         promise = require("../../lib/promise")(fakeBluebird);
     });
     methods.forEach((name) => {
-        it("exposes the " + name + " method", function () {
+        it(`exposes the ${name} method`, () => {
             expect(promise[name]).toEqual(jasmine.any(Function));
         });
     });
-    it("exposes the create method (not tested previously)", function () {
+    it("exposes the create method (not tested previously)", () => {
         expect(promise.create).toEqual(jasmine.any(Function));
     });
-    it("creates a new promise", function () {
+    it("creates a new promise", () => {
         var testedCallback;
 
         testedCallback = false;

--- a/spec/lib/random.spec.js
+++ b/spec/lib/random.spec.js
@@ -52,12 +52,12 @@ describe("random", () => {
                 expected: "abcdwxyzABCDWXYZ0189-_testing--__"
             }
         ].forEach((scenario) => {
-            it("sends the right amount of binary data to base64: length " + scenario.desiredLength, (done) => {
+            it(`sends the right amount of binary data to base64: length ${scenario.desiredLength}`, (done) => {
                 random.randomIdAsync(scenario.desiredLength).then(() => {
                     expect(base64Mock.encode.mostRecentCall.args[0].length).toBe(scenario.binLength);
                 }).then(done, done);
             });
-            it("replaced + and /: length " + scenario.desiredLength, () => {
+            it(`replaced + and /: length ${scenario.desiredLength}`, () => {
                 random.randomIdAsync(scenario.desiredLength).then((pass) => {
                     expect(pass).toEqual(scenario.expected);
                 });

--- a/spec/lib/record.spec.js
+++ b/spec/lib/record.spec.js
@@ -40,7 +40,7 @@ describe("record", () => {
             return promiseMock.resolve(new Buffer("decrypted", "binary"));
         });
         encryptionMock.encryptAsync.andCallFake((buffer, key, hmac, cipher) => {
-            return promiseMock.resolve(new Buffer("encrypted-" + cipher, "binary"));
+            return promiseMock.resolve(new Buffer(`encrypted-${cipher}`, "binary"));
         });
         fsMock = jasmine.createSpyObj("fs", [
             "readFile"
@@ -176,7 +176,7 @@ describe("record", () => {
             expect(args[0].toString("binary")).toBe("deserialized data");
 
             // Compression
-            args = zlibMock.inflateRaw.mostRecentCall.args
+            args = zlibMock.inflateRaw.mostRecentCall.args;
             expect(args[0].toString("binary")).toBe("decrypted");
 
             // Deserialize again
@@ -198,7 +198,7 @@ describe("record", () => {
             ]);
             bufferSerializerMock.fromBuffer.andReturn({
                 data: "deserialized data",
-                expires: expires
+                expires
             });
         });
         it("deserializes when expires is after today", (done) => {
@@ -206,7 +206,7 @@ describe("record", () => {
             record.thawAsync({}, "").then((result) => {
                 expect(result).toEqual({
                     data: "deserialized data",
-                    expires: expires
+                    expires
                 });
             }).then(done, done);
         });

--- a/spec/lib/rest-middleware.spec.js
+++ b/spec/lib/rest-middleware.spec.js
@@ -1,14 +1,14 @@
 "use strict";
 
 describe("restMiddleware", () => {
-    var helmetMock, restMiddleware, serverMock, restifyMock, restifyLinks;
+    var helmetMock, restifyLinks, restifyMock, restMiddleware, serverMock;
 
     /**
      * Tests the common middleware set up when calling restMiddleware.
      * StandardLinks is tested on it's own due to the nature of what
      * needs to be tested there.
      */
-    function expectNormalMiddlewareWasCalled () {
+    function expectNormalMiddlewareWasCalled() {
         [
             helmetMock.frameguard,
             helmetMock.ieNoOpen,
@@ -24,6 +24,13 @@ describe("restMiddleware", () => {
         });
     }
 
+    /**
+     * This generates fake middleware that are spies.
+     *
+     * @param {string} name
+     * @param {Array.<string>} methods
+     * @return {Object} middleware
+     */
     function mockMiddleware(name, methods) {
         var middleware;
 

--- a/spec/lib/secure-hash.spec.js
+++ b/spec/lib/secure-hash.spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-describe("secureHash", ()  => {
+describe("secureHash", () => {
     var crypto, secureHash, secureHashConfig;
 
     secureHashConfig = {

--- a/spec/lib/storage.spec.js
+++ b/spec/lib/storage.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("storage", () => {
-    var containerMock,create;
+    var containerMock, create;
 
     beforeEach(() => {
         containerMock = jasmine.createSpyObj("containerMock", [

--- a/spec/lib/storage/s3.spec.js
+++ b/spec/lib/storage/s3.spec.js
@@ -4,7 +4,15 @@ describe("storage/s3", () => {
     var awsSdkMock, promiseMock, s3;
 
     beforeEach(() => {
+        /**
+         * Fake S3 class
+         */
         class S3Fake {
+            /**
+             * Set up spies on the methods
+             *
+             * @param {*} params No influence on this class
+             */
             constructor(params) {
                 this.params = params;
                 this.getObjectAsync = jasmine.createSpy("getObjectAsync");
@@ -19,8 +27,8 @@ describe("storage/s3", () => {
                     "putObjectAsync"
                 ].forEach((method) => {
                     this[method] = jasmine.createSpy(method);
-                    this[method].andCallFake((params) => {
-                        return promiseMock.resolve(params);
+                    this[method].andCallFake((paramsInside) => {
+                        return promiseMock.resolve(paramsInside);
                     });
                 });
             }

--- a/spec/lib/web-server.spec.js
+++ b/spec/lib/web-server.spec.js
@@ -1,3 +1,5 @@
+/* eslint consistent-this:"off" */
+
 "use strict";
 
 describe("WebServer", () => {
@@ -6,8 +8,13 @@ describe("WebServer", () => {
     beforeEach(() => {
         var WebServer;
 
-        // Set up a fake MiddlewareProfiler object
+        /**
+         * Set up a fake MiddlewareProfiler object
+         */
         class MiddlewareProfilerMock {
+            /**
+             * Construct an object.  Spies on necessary functions.
+             */
             constructor() {
                 middlewareProfiler = this;
                 [
@@ -54,6 +61,9 @@ describe("WebServer", () => {
     });
     describe(".addMiddleware()", () => {
         it("adds middleware without a route", (done) => {
+            /**
+             * Meaningless function used only for testing
+             */
             function testFn() {}
 
             expect(restifyServer.use).not.toHaveBeenCalled();
@@ -63,6 +73,9 @@ describe("WebServer", () => {
             }).then(done, done);
         });
         it("adds middleware with a route", (done) => {
+            /**
+             * Meaningless function used only for testing
+             */
             function testFn() {}
 
             expect(restifyServer.use).not.toHaveBeenCalled();
@@ -72,8 +85,14 @@ describe("WebServer", () => {
             }).then(done, done);
         });
         it("adds more than one middleware", (done) => {
+            /**
+             * Meaningless function used only for testing
+             */
             function testFn1() {}
 
+            /**
+             * Meaningless function used only for testing
+             */
             function testFn2() {}
 
             expect(restifyServer.use).not.toHaveBeenCalled();
@@ -100,12 +119,19 @@ describe("WebServer", () => {
     describe(".configure()", () => {
         var defaultConfig;
 
+        /**
+         * Tests the configuration and confirms that it is set right.
+         *
+         * @param {Object} input What to pass in
+         * @param {Object} expected How to override the defaults
+         * @param {Function} done Signal completion of the test
+         */
         function testConfig(input, expected, done) {
             var actual;
 
             // Set defaults in expected
             Object.keys(defaultConfig).forEach((key) => {
-                if (expected[key] === undefined) {
+                if (typeof expected[key] === "undefined") {
                     expected[key] = defaultConfig[key];
                 }
             });
@@ -128,8 +154,7 @@ describe("WebServer", () => {
                 httpsServerOptions: null,
                 name: "OpenToken API",
                 proxyProtocol: false,
-                spdy: null,
-                version: null
+                spdy: null
             };
         });
         it("works with no configuration", (done) => {
@@ -148,15 +173,15 @@ describe("WebServer", () => {
         });
         it("reads certificate and key files", (done) => {
             fs.readFileAsync.andCallFake((fn) => {
-                if (fn == "keyfile") {
+                if (fn === "keyfile") {
                     return promiseMock.resolve("keyfile ok");
                 }
 
-                if (fn == "certfile") {
+                if (fn === "certfile") {
                     return promiseMock.resolve("certfile ok");
                 }
 
-                return promiseMock.reject("Invalid file: " + fn.toString());
+                return promiseMock.reject(`Invalid file: ${fn.toString()}`);
             });
             testConfig({
                 certificateFile: "certfile",
@@ -186,29 +211,6 @@ describe("WebServer", () => {
             }, {
                 spdy: 123
             }, done);
-        });
-        it("passes version", (done) => {
-            testConfig({
-                version: "flowers"
-            }, {
-                version: "flowers"
-            }, done);
-        });
-        it("forces the baseUrl to not have a trailing slash", (done) => {
-            var args;
-
-            webServer.configure({
-                baseUrl: "/bunnies/"
-            });
-            webServer.startServerAsync().then(() => {
-                expect(restMiddleware).toHaveBeenCalled();
-                expect(restMiddleware.callCount).toBe(1);
-                args = restMiddleware.mostRecentCall.args;
-                expect(args.length).toBe(2);
-                expect(args[1]).toBe(restifyServer);
-                expect(args[0]).toEqual(jasmine.any(Object));
-                expect(args[0].baseUrl).toBe("/bunnies");
-            }).then(done, done);
         });
         it("does not trim a baseUrl without a trailing slash", (done) => {
             webServer.configure({
@@ -252,7 +254,9 @@ describe("WebServer", () => {
                 expect(restifyServer.listen).toHaveBeenCalled();
                 expect(restifyServer.listen.callCount).toBe(1);
                 args = restifyServer.listen.mostRecentCall.args;
-                expect(args[0]).toBe(8080);  // default port
+
+                // default port
+                expect(args[0]).toBe(8080);
                 expect(args[1]).toEqual(jasmine.any(Function));
                 expect(args.length).toBe(2);
             }).then(done, done);
@@ -262,13 +266,13 @@ describe("WebServer", () => {
 
             webServer.startServerAsync().then(() => {
                 callback = restifyServer.listen.mostRecentCall.args[1];
-                expect(function() {
+                expect(() => {
                     callback();
                 }).not.toThrow();
             }).then(done, done);
         });
         it("executes the uncaughtException callback", (done) => {
-            var callback, args, uncaughtCallback, req, res, route;
+            var args, callback, req, res, route, uncaughtCallback;
 
             req = jasmine.createSpy("req");
             res = jasmine.createSpyObj("res", [
@@ -277,7 +281,7 @@ describe("WebServer", () => {
             ]);
             webServer.startServerAsync().then(() => {
                 callback = restifyServer.listen.mostRecentCall.args[1];
-                expect(function () {
+                expect(() => {
                     callback();
                 });
                 expect(restifyServer.on).toHaveBeenCalled();
@@ -286,7 +290,9 @@ describe("WebServer", () => {
                 expect(args[0]).toBe("uncaughtException");
                 expect(args[1]).toEqual(jasmine.any(Function));
                 uncaughtCallback = args[1];
-                uncaughtCallback(req, res, route, {"error": true});
+                uncaughtCallback(req, res, route, {
+                    error: true
+                });
                 expect(loggerMock.error).toHaveBeenCalled();
                 expect(res.send).toHaveBeenCalledWith(500);
                 expect(res.write).not.toHaveBeenCalled();

--- a/spec/mock/logger-mock.js
+++ b/spec/mock/logger-mock.js
@@ -10,6 +10,6 @@ logger = {};
     "info",
     "warn"
 ].forEach((methodName) => {
-    logger[methodName] = jasmine.createSpy("logger." + methodName);
+    logger[methodName] = jasmine.createSpy(`logger.${methodName}`);
 });
 module.exports = logger;

--- a/spec/mock/ot-date-mock.js
+++ b/spec/mock/ot-date-mock.js
@@ -1,5 +1,10 @@
 "use strict";
 
+/**
+ * Fake class to mock OtDate.
+ *
+ * @param {Date} d Date value to use for mocking
+ */
 function OtDateMock(d) {
     this.date = d;
 
@@ -14,7 +19,6 @@ function OtDateMock(d) {
     this.isBefore = jasmine.createSpy("isBefore").andCallFake((other) => {
         return this.date < other.date;
     });
-
 
 
     /**
@@ -39,7 +43,7 @@ function OtDateMock(d) {
      * @return {Buffer}
      */
     this.toBuffer = jasmine.createSpy("toBuffer").andCallFake((dest, offset) => {
-        if (! dest) {
+        if (!dest) {
             dest = new Buffer(4);
             offset = 0;
         }

--- a/spec/mock/promise-mock.js
+++ b/spec/mock/promise-mock.js
@@ -1,6 +1,8 @@
+/* eslint guard-for-in:"off" */
+
 "use strict";
 
-/*global Promise*/
+/* global Promise*/
 module.exports = {
     /**
      * Resolves when all promises are resolved.
@@ -11,10 +13,16 @@ module.exports = {
      * @param {Array.<Promise>} promises
      * @return {Promise.<Array>}
      */
-    all: function (promises) {
+    all(promises) {
         return new Promise((resolve, reject) => {
             var isDone, needed, result;
 
+            /**
+             * Handle a resolved promise
+             *
+             * @param {number} index
+             * @param {*} val
+             */
             function resolved(index, val) {
                 if (isDone) {
                     return;
@@ -29,6 +37,11 @@ module.exports = {
                 }
             }
 
+            /**
+             * Handle a rejected promise
+             *
+             * @param {*} val
+             */
             function rejected(val) {
                 if (isDone) {
                     return;
@@ -54,10 +67,15 @@ module.exports = {
      * @param {Array.<Promise>} promises
      * @return {Promise.<*>}
      */
-    any: function (promises) {
+    any(promises) {
         return new Promise((resolve, reject) => {
             var isDone;
 
+            /**
+             * Handle a resolved promise
+             *
+             * @param {*} val
+             */
             function resolved(val) {
                 if (isDone) {
                     return;
@@ -67,6 +85,11 @@ module.exports = {
                 resolve(val);
             }
 
+            /**
+             * Handle a rejected promise
+             *
+             * @param {*} val
+             */
             function rejected(val) {
                 if (isDone) {
                     return;
@@ -87,10 +110,10 @@ module.exports = {
     /**
      * Creates a Promise using ES6 syntax
      *
-     * @param {Function(resolve,reject)} cb
+     * @param {Function} cb(resolve,reject)
      * @return {Promise.<*>}
      */
-    create: function (cb) {
+    create(cb) {
         return new Promise(cb);
     },
 
@@ -99,10 +122,10 @@ module.exports = {
      * Provides a "done" callback to a function so you can wrap
      * Node-style callbacks and make them return promises.
      *
-     * @param {Function(done)} fn
+     * @param {Function} fn(done)
      * @return {Promise.<*>}
      */
-    fromCallback: function (fn) {
+    fromCallback(fn) {
         return new Promise((resolve, reject) => {
             fn((err, val) => {
                 if (err) {
@@ -121,7 +144,7 @@ module.exports = {
      * @param {Function} fn
      * @return {Promise.<*>}
      */
-    promisify: function (fn) {
+    promisify(fn) {
         return function () {
             var args;
 
@@ -135,7 +158,7 @@ module.exports = {
                         resolve(val);
                     }
                 });
-                fn.apply(this, args);
+                fn.apply(null, args);
             });
         };
     },
@@ -148,14 +171,14 @@ module.exports = {
      * @param {Object} object
      * @return {Object}
      */
-    promisifyAll: function (object) {
+    promisifyAll(object) {
         var name, result;
 
         result = {};
 
         for (name in object) {
             result[name] = object[name];
-            result[name + "Async"] = this.promisify(object[name]);
+            result[`${name}Async`] = this.promisify(object[name]);
         }
 
         return result;
@@ -170,10 +193,13 @@ module.exports = {
      * @param {Object} obj
      * @return {Promise.<Object>}
      */
-    props: function (obj) {
+    props(obj) {
         return new Promise((resolve, reject) => {
             var needed, result;
 
+            /**
+             * Handles a successful resolution
+             */
             function doneWithOne() {
                 needed -= 1;
 
@@ -182,7 +208,9 @@ module.exports = {
                 }
             }
 
-            needed = 1; // Fake number, removed later
+            // This is a fake number and is removed later.  It exists
+            // in case the first promise is already resolved.
+            needed = 1;
             result = {};
             Object.keys(obj).forEach((key) => {
                 needed += 1;
@@ -192,11 +220,13 @@ module.exports = {
                     result[key] = resolvedValue;
                     doneWithOne();
                 }, (rejectedValue) => {
-                    needed = -1;  // Force this to never call resolve();
+                    // Force this to never call resolve();
+                    needed = -1;
                     reject(rejectedValue);
                 });
             });
 
+            // This removes that fake number added earlier.
             doneWithOne();
         });
     },
@@ -208,7 +238,7 @@ module.exports = {
      * @param {*} val
      * @return {Promise}
      */
-    reject: function (val) {
+    reject(val) {
         return new Promise((resolve, reject) => {
             reject(val);
         });
@@ -221,7 +251,7 @@ module.exports = {
      * @param {*} val
      * @return {Promise.<*>}
      */
-    resolve: function (val) {
+    resolve(val) {
         return new Promise((resolve) => {
             resolve(val);
         });
@@ -251,7 +281,7 @@ module.exports = {
      * @param {Function} fn
      * @return {Promise.<*>}
      */
-    try: function (fn) {
+    try(fn) {
         return new Promise((resolve, reject) => {
             try {
                 resolve(fn());

--- a/spec/mock/random-mock.js
+++ b/spec/mock/random-mock.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 var random;
 
@@ -13,7 +13,7 @@ random.bufferAsync.andCallFake((size) => {
     buff = new Buffer(size);
     buff.fill(0x42);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         resolve(buff);
     });
 });
@@ -24,7 +24,7 @@ random.randomIdAsync.andCallFake((size) => {
     buff = new Buffer(size);
     buff.fill(0x42);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         resolve(buff.toString());
     });
 });

--- a/spec/mock/response.js
+++ b/spec/mock/response.js
@@ -8,7 +8,7 @@ response = jasmine.createSpyObj("response", [
 ]);
 response.contentType = "auto";
 response.setHeader.andCallFake((header, value) => {
-    if (header.toLowerCase() == "content-type") {
+    if (header.toLowerCase() === "content-type") {
         response.contentType = value;
     }
 });

--- a/spec/mock/storage-mock.js
+++ b/spec/mock/storage-mock.js
@@ -1,6 +1,12 @@
 "use strict";
 
+/**
+ * Fake storage object
+ */
 class StorageMock {
+    /**
+     * Sets up spies on all methods.
+     */
     constructor() {
         [
             "configure",
@@ -13,8 +19,8 @@ class StorageMock {
         this.configure.andCallFake(() => {
             return this;
         });
-        this.delAsync.andCallFake((directory) => {
-            return new Promise((resolve, reject) => {
+        this.delAsync.andCallFake(() => {
+            return new Promise((resolve) => {
                 resolve(true);
             });
         });
@@ -22,23 +28,23 @@ class StorageMock {
             var dataToReturn;
 
             if (directory.match("registration")) {
-                dataToReturn = '{"data": "thing"}';
+                dataToReturn = "{\"data\": \"thing\"}";
             }
 
             if (directory.match("some/place/someIdhere")) {
-                dataToReturn = '{"accountId": "unhashedAccountId", "email": "some.one@example.net"}';
+                dataToReturn = "{\"accountId\": \"unhashedAccountId\", \"email\": \"some.one@example.net\"}";
             }
 
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve) => {
                 resolve(new Buffer(dataToReturn, "binary"));
             });
         });
         this.putAsync.andCallFake(() => {
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve) => {
                 resolve(true);
             });
         });
     }
-};
+}
 
 module.exports = new StorageMock();

--- a/spec/mock/web-server-mock.js
+++ b/spec/mock/web-server-mock.js
@@ -8,7 +8,15 @@ var promiseMock;
 
 promiseMock = require("./promise-mock");
 
+/**
+ * This is a fake WebServer
+ */
 class WebServerMock {
+    /**
+     * Create the object.  Sets up spies on new instances.
+     *
+     * @param {Object} config
+     */
     constructor(config) {
         this.config = config;
 

--- a/spec/route/index.spec.js
+++ b/spec/route/index.spec.js
@@ -10,7 +10,7 @@ describe("route: /", () => {
         expect(factory).toEqual(jasmine.any(Function));
     });
     describe("factory results", () => {
-        var route, req, res;
+        var req, res, route;
 
         beforeEach(() => {
             route = factory();


### PR DESCRIPTION
This adds a much more strict .eslintrc (also converts it to YAML).  I've
ignored node_modules/ and coverage/, but the rest of the files now get
scanned when running "npm test".

There were many little changes that needed to get made so the linter
would not find more problems.  It's a little strict, like jslint, but
that means our code will be more uniform.