### PR TITLE
Promisify node modules that are functions in themselves

### DIFF
--- a/lib/promisifier.js
+++ b/lib/promisifier.js
@@ -2,6 +2,10 @@
 
 module.exports = (promise) => {
     return (otherModule) => {
+        if (typeof otherModule === "function") {
+            otherModule = promise.promisify(otherModule);
+        }
+
         return promise.promisifyAll(otherModule);
     };
 };

--- a/spec/lib/promisifier.spec.js
+++ b/spec/lib/promisifier.spec.js
@@ -23,4 +23,17 @@ describe("promisifier", () => {
         expect(promisifier(obj)).toBe(result);
         expect(promiseMock.promisifyAll).toHaveBeenCalledWith(obj);
     });
+    it("promisifies a function as well", () => {
+        var fn, result;
+
+        fn = () => {};
+        result = () => {};
+        spyOn(promiseMock, "promisify").andReturn(result);
+        spyOn(promiseMock, "promisifyAll").andCallFake((x) => {
+            return x;
+        });
+        expect(promisifier(fn)).toBe(result);
+        expect(promiseMock.promisify).toHaveBeenCalledWith(fn);
+        expect(promiseMock.promisifyAll).toHaveBeenCalledWith(result);
+    });
 });


### PR DESCRIPTION
This is specifically to get the server to work again with glob.  When
you `require("glob")`, it returns a function with additional methods.
That function itself needs to be promisified as well.