### PR TITLE
Adding test to confirm TOTP key is not displayed

### DIFF
--- a/spec/lib/registration/registration-manager.spec.js
+++ b/spec/lib/registration/registration-manager.spec.js
@@ -261,5 +261,26 @@ describe("registrationManager", () => {
                 });
             }).then(done, done);
         });
+        it("does not return the totp if the record is confirmed", (done) => {
+            registrationServiceMock.getAsync.andReturn(promiseMock.resolve({
+                confirmationCode: "code",
+                email: "user@example.com",
+                extraProperty: "discarded when saved as an account",
+                passwordHash: "hashed password",
+                passwordHashConfig: "passwordHashConfig",
+                totp: {
+                    key: "totp key"
+                },
+                totpConfirmed: true
+            }));
+            factory().secureInfoAsync("id").then((result) => {
+                expect(result).toEqual({
+                    id: "id",
+                    secureInfo: {
+                        passwordHashConfig: "passwordHashConfig"
+                    }
+                });
+            }).then(done, done);
+        });
     });
 });


### PR DESCRIPTION
This should not be displayed once the TOTP key is verified.  Bringing up code coverage again.