### PR TITLE
Avoid shadowing of variable in scope

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -95,14 +95,14 @@ module.exports = (cryptoAsync, encoding, promise) => {
 
         switch (config.type) {
         case "pbkdf2":
-            promise = pbkdf2Async(data, config);
+            result = pbkdf2Async(data, config);
             break;
 
         default:
             return promise.reject(new Error("Invalid hash type configuration"));
         }
 
-        result = promise.then((hash) => {
+        result = result.then((hash) => {
             return encoding.encode(hash, config.encoding);
         });
 


### PR DESCRIPTION
`promise` is already defined.  Sadly, this passed tests but would not
work in real life as it redefines `promise` in the outer scope.