### PR TITLE
Using the storage selection file

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -45,7 +45,7 @@ moduleDefs = {
     schema: "./schema",
     serialization: "./serialization",
     sessionManager: "./session-manager",
-    storage: "./storage/s3",
+    storage: "./storage",
     storageServiceFactory: "./storage-service-factory",
     totp: "./mfa/totp",
     util: "./util",


### PR DESCRIPTION
We were using the S3 module directly, though that is not what we should
have been doing.  The purpose of storage.js is to look at the config and
select the correct storage engine to use.