### PR TITLE
Updating the validation middleware

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -52,7 +52,7 @@ moduleDefs = {
     storageServiceFactory: "./storage-service-factory",
     totp: "./mfa/totp",
     util: "./util",
-    validateRequestMiddleware: "./middleware/validate-request-middleware",
+    validateRequestBodyMiddleware: "./middleware/validate-request-body-middleware",
     validateSessionMiddleware: "./middleware/validate-session-middleware",
     WebServer: "./web-server"
 };

--- a/lib/middleware/validate-request-body-middleware.js
+++ b/lib/middleware/validate-request-body-middleware.js
@@ -10,7 +10,7 @@ module.exports = (chainMiddleware, restifyPlugins, schema) => {
     /**
      * Specify the schema file to validate the incoming request against.
      *
-     * @param {string} schemaPath
+     * @param {string} schemaPath Validation and processing of body.
      * @return {Function} middleware
      */
     return (schemaPath) => {
@@ -25,7 +25,7 @@ module.exports = (chainMiddleware, restifyPlugins, schema) => {
             if (!req.body || schema.validate(req.body, schemaPath)) {
                 // This does not go to the client, but it should.
                 // https://github.com/opentoken-io/opentoken/issues/96
-                res.send(400, new Error(`Did not validate against schema: ${schemaPath}`));
+                res.send(400, new Error(`Body did not validate against schema: ${schemaPath}`));
 
                 return next(false);
             }

--- a/route/account/_account-id/access-code/index.js
+++ b/route/account/_account-id/access-code/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = (server, path, options) => {
-    return options.container.call((accessCodeManager, config, sessionManager, validateRequestMiddleware, validateSessionMiddleware) => {
+    return options.container.call((accessCodeManager, config, sessionManager, validateRequestBodyMiddleware, validateSessionMiddleware) => {
         return {
             get: [
                 validateSessionMiddleware(server),
@@ -27,7 +27,7 @@ module.exports = (server, path, options) => {
             ],
             name: "account-accessCode",
             post: [
-                validateRequestMiddleware("/account/access-code-request.json"),
+                validateRequestBodyMiddleware("/account/access-code-request.json"),
                 validateSessionMiddleware(server),
                 (req, res, next) => {
                     accessCodeManager.createAsync(req.params.accountId, req.body).then((codeInfo) => {

--- a/route/account/_account-id/login/index.js
+++ b/route/account/_account-id/login/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = (server, path, options) => {
-    return options.container.call((accountManager, config, loginCookie, validateRequestMiddleware) => {
+    return options.container.call((accountManager, config, loginCookie, validateRequestBodyMiddleware) => {
         return {
             get(req, res, next) {
                 // Clear any existing cookies
@@ -27,7 +27,7 @@ module.exports = (server, path, options) => {
             },
             name: "account-login",
             post: [
-                validateRequestMiddleware("/account/login-request.json"),
+                validateRequestBodyMiddleware("/account/login-request.json"),
                 (req, res, next) => {
                     accountManager.loginAsync(req.params.accountId, req.body).then((login) => {
                         var accountRoute;

--- a/route/registration/_id/index.js
+++ b/route/registration/_id/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = (server, path, options) => {
-    return options.container.call((registrationManager, validateRequestMiddleware) => {
+    return options.container.call((registrationManager, validateRequestBodyMiddleware) => {
         var getResponse;
 
         getResponse = require("./_get-response")(server);
@@ -14,7 +14,7 @@ module.exports = (server, path, options) => {
             },
             name: "registration-secure",
             post: [
-                validateRequestMiddleware("/registration/secure-request.json"),
+                validateRequestBodyMiddleware("/registration/secure-request.json"),
                 (req, res, next) => {
                     registrationManager.secureAsync(req.params.id, req.body, server).then((secureInfoGroup) => {
                         res.links({

--- a/route/registration/index.js
+++ b/route/registration/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = (server, path, options) => {
-    return options.container.call((registrationManager, validateRequestMiddleware) => {
+    return options.container.call((registrationManager, validateRequestBodyMiddleware) => {
         var getResponse;
 
         getResponse = require("./_id/_get-response")(server);
@@ -9,7 +9,7 @@ module.exports = (server, path, options) => {
         return {
             name: "registration-register",
             post: [
-                validateRequestMiddleware("/registration/register-request.json"),
+                validateRequestBodyMiddleware("/registration/register-request.json"),
                 (req, res, next) => {
                     registrationManager.registerAsync(req.body).then((secureInfoGroup) => {
                         var url;

--- a/spec/helper/route-tester.helper.js
+++ b/spec/helper/route-tester.helper.js
@@ -96,29 +96,12 @@ jasmine.routeTester = (routePath, containerOverrideFn, callback) => {
             routeTester = {};
 
             beforeEach(() => {
-                var config, container, serverMock, validateRequestMiddleware;
+                var config, container, serverMock;
 
                 container = require("../../lib/dependencies");
-                validateRequestMiddleware = jasmine.createSpy("validateRequestMiddleware").andCallFake((schemaPath) => {
-                    return (req, res, next) => {
-                        var result;
-
-                        result = container.resolve("schema").validate(req.body, schemaPath);
-                        routeTester.validationResult = result;
-
-                        if (result) {
-                            res.send(400, new Error(`Did not validate against schema: ${schemaPath}`));
-
-                            return next(false);
-                        }
-
-                        return next();
-                    };
-                });
                 config = container.resolve("config");
                 config.baseDir = "/";
                 container.register("config", config);
-                container.register("validateRequestMiddleware", validateRequestMiddleware);
 
                 if (containerOverrideFn) {
                     containerOverrideFn(container);

--- a/spec/lib/middleware/validate-request-body-middleware.spec.js
+++ b/spec/lib/middleware/validate-request-body-middleware.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
-describe("validateRequestMiddleware", () => {
-    var chainMiddlewareMock, restifyPluginsMock, schemaMock, validateRequestMiddleware;
+describe("validateRequestBodyMiddleware", () => {
+    var chainMiddlewareMock, restifyPluginsMock, schemaMock, validateRequestBodyMiddleware;
 
     beforeEach(() => {
         chainMiddlewareMock = jasmine.createSpy("chainMiddlewareMock");
@@ -12,17 +12,17 @@ describe("validateRequestMiddleware", () => {
             "validate"
         ]);
         schemaMock.validate.andReturn(null);
-        validateRequestMiddleware = require("../../../lib/middleware/validate-request-middleware")(chainMiddlewareMock, restifyPluginsMock, schemaMock);
+        validateRequestBodyMiddleware = require("../../../lib/middleware/validate-request-body-middleware")(chainMiddlewareMock, restifyPluginsMock, schemaMock);
     });
     it("parses the body", () => {
-        validateRequestMiddleware("schema");
+        validateRequestBodyMiddleware("schema");
         expect(restifyPluginsMock.bodyParser).toHaveBeenCalled();
     });
     describe("validation against schema", () => {
         var middleware, req, res;
 
         beforeEach(() => {
-            validateRequestMiddleware("schema");
+            validateRequestBodyMiddleware("schema");
             middleware = chainMiddlewareMock.mostRecentCall.args[1];
             req = require("../../mock/request-mock")();
             res = require("../../mock/response-mock")();

--- a/spec/mock/middleware/validate-request-body-middleware-mock.js
+++ b/spec/mock/middleware/validate-request-body-middleware-mock.js
@@ -7,7 +7,7 @@ container = require("../../../lib/dependencies");
 module.exports = () => {
     var middleware, middlewareFactory;
 
-    middleware = jasmine.createSpy("validate-request-body-middleware-mock-middleware").andCallFake((req, res, next) => {
+    middleware = jasmine.createSpy("validateRequestBodyMiddlewareMockMiddleware").andCallFake((req, res, next) => {
         var result;
 
         result = container.resolve("schema").validate(req.body, middleware.schemaPath);
@@ -22,7 +22,7 @@ module.exports = () => {
     });
 
     // This factory only returns the same middleware over and over.
-    middlewareFactory = jasmine.createSpy("validate-request-body-middleware-mock-factory").andCallFake((schemaPath) => {
+    middlewareFactory = jasmine.createSpy("validateRequestBodyMiddlewareMock").andCallFake((schemaPath) => {
         middleware.schemaPath = schemaPath;
 
         return middleware;

--- a/spec/mock/middleware/validate-request-body-middleware-mock.js
+++ b/spec/mock/middleware/validate-request-body-middleware-mock.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var container;
+
+container = require("../../../lib/dependencies");
+
+module.exports = () => {
+    var middleware, middlewareFactory;
+
+    middleware = jasmine.createSpy("validate-request-body-middleware-mock-middleware").andCallFake((req, res, next) => {
+        var result;
+
+        result = container.resolve("schema").validate(req.body, middleware.schemaPath);
+
+        if (result) {
+            res.send(400, new Error(`Did not validate against schema: ${middleware.schemaPath}`));
+
+            return next(false);
+        }
+
+        return next();
+    });
+
+    // This factory only returns the same middleware over and over.
+    middlewareFactory = jasmine.createSpy("validate-request-body-middleware-mock-factory").andCallFake((schemaPath) => {
+        middleware.schemaPath = schemaPath;
+
+        return middleware;
+    });
+
+    return middlewareFactory;
+};

--- a/spec/mock/middleware/validate-session-middleware-mock.js
+++ b/spec/mock/middleware/validate-session-middleware-mock.js
@@ -3,12 +3,12 @@
 module.exports = () => {
     var middleware, middlewareFactory;
 
-    middleware = jasmine.createSpy("validate-session-middleware-mock-middleware").andCallFake((req, res, next) => {
+    middleware = jasmine.createSpy("validateSessionMiddlewareMockMiddleware").andCallFake((req, res, next) => {
         next();
     });
 
     // This factory only returns the same middleware over and over.
-    middlewareFactory = jasmine.createSpy("validate-session-middleware-mock-factory").andReturn(middleware);
+    middlewareFactory = jasmine.createSpy("validateSessionMiddlewareMock").andReturn(middleware);
 
     return middlewareFactory;
 };

--- a/spec/route/account/_account-id/access-code/index.spec.js
+++ b/spec/route/account/_account-id/access-code/index.spec.js
@@ -3,11 +3,15 @@
 var accessCodeManagerMock, sessionManagerMock, validateSessionMiddlewareMock;
 
 jasmine.routeTester("/account/_account-id/access-code/", (container) => {
+    var validateRequestBodyMiddlewareMock;
+
     accessCodeManagerMock = require("../../../../mock/access-code-manager-mock")();
     sessionManagerMock = require("../../../../mock/session-manager-mock")();
+    validateRequestBodyMiddlewareMock = require("../../../../mock/middleware/validate-request-body-middleware-mock")();
     validateSessionMiddlewareMock = require("../../../../mock/middleware/validate-session-middleware-mock")();
     container.register("accessCodeManager", accessCodeManagerMock);
     container.register("sessionManager", sessionManagerMock);
+    container.register("validateRequestBodyMiddleware", validateRequestBodyMiddlewareMock);
     container.register("validateSessionMiddleware", validateSessionMiddlewareMock);
 }, (routeTester) => {
     beforeEach(() => {

--- a/spec/route/account/_account-id/login/index.spec.js
+++ b/spec/route/account/_account-id/login/index.spec.js
@@ -3,11 +3,15 @@
 var accountManagerMock, loginCookieMock, promiseMock;
 
 jasmine.routeTester("/account/_account-id/login/", (container) => {
-    promiseMock = require("../../../../mock/promise-mock")();
+    var validateRequestBodyMiddlewareMock;
+
     accountManagerMock = require("../../../../mock/account-manager-mock")();
     loginCookieMock = require("../../../../mock/login-cookie-mock")();
+    promiseMock = require("../../../../mock/promise-mock")();
+    validateRequestBodyMiddlewareMock = require("../../../../mock/middleware/validate-request-body-middleware-mock")();
     container.register("accountManager", accountManagerMock);
     container.register("loginCookie", loginCookieMock);
+    container.register("validateRequestBodyMiddleware", validateRequestBodyMiddlewareMock);
 }, (routeTester) => {
     beforeEach(() => {
         routeTester.req.params.accountId = "account-id";

--- a/spec/route/registration/_id/index.spec.js
+++ b/spec/route/registration/_id/index.spec.js
@@ -3,8 +3,12 @@
 var registrationManagerMock;
 
 jasmine.routeTester("/registration/_id", (container) => {
+    var validateRequestBodyMiddlewareMock;
+
     registrationManagerMock = require("../../../mock/registration-manager-mock")();
+    validateRequestBodyMiddlewareMock = require("../../../mock/middleware/validate-request-body-middleware-mock")();
     container.register("registrationManager", registrationManagerMock);
+    container.register("validateRequestBodyMiddleware", validateRequestBodyMiddlewareMock);
 }, (routeTester) => {
     it("exports the right methods", () => {
         expect(Object.keys(routeTester.exports).sort()).toEqual([

--- a/spec/route/registration/index.spec.js
+++ b/spec/route/registration/index.spec.js
@@ -3,8 +3,12 @@
 var registrationManagerMock;
 
 jasmine.routeTester("/registration", (container) => {
+    var validateRequestBodyMiddlewareMock;
+
     registrationManagerMock = require("../../mock/registration-manager-mock")();
+    validateRequestBodyMiddlewareMock = require("../../mock/middleware/validate-request-body-middleware-mock")();
     container.register("registrationManager", registrationManagerMock);
+    container.register("validateRequestBodyMiddleware", validateRequestBodyMiddlewareMock);
 }, (routeTester) => {
     it("exports the right methods", () => {
         expect(Object.keys(routeTester.exports).sort()).toEqual([


### PR DESCRIPTION
This renames the middleware to indicate that it only validates the body.
There will be a new middleware that validates the query string, which is
why this change needed to be made.

I also extracted the mock middleware into its own mock file and had to
then update four route tests to inject the mock into the container.

The majority of the rest of the changes are simply updates to use the
new middleware's name.