### PR TITLE
Various fixes to eliminate errors of multiple types

### DIFF
--- a/doc/strength-and-numbers.md
+++ b/doc/strength-and-numbers.md
@@ -62,7 +62,7 @@ In order to attack the algorithms used and without knowing any other weaknesses,
 
 First, we must break AES.  The key size that is used is 32 bytes.  That's 2^256 possibilities, which is about 1.16E77.  With the above supercomputer we can fully scan the keyspace in 4E58 years.  Really, we'd only have to scan about half of that in order to get a 50% chance of finding the key.  Assuming each atom of Earth was one of these supercomputers, it would still take 298,579,912 years to find it.
 
-Whirlpool uses a similarly sized key of 32 bytes.  Again, the number of possibilities for scanning the entire keyspace are the same.  Because it's implemented slower, the supercomputer now takes 1.35E59 years and finally will scan all possibilites after 1 billion years (with a 50% chance after 500 million years).
+Whirlpool uses a similarly sized key of 32 bytes.  Again, the number of possibilities for scanning the entire keyspace are the same.  Because it's implemented slower, the supercomputer now takes 1.35E59 years.  The "every atom of Earth is a supercomputer" would scan all possibilities after 1 billion years (with a 50% chance after 500 million years).
 
 Because the records are stored as double-encrypted payloads, even huge advances in bypassing some of the encryption will not help tremendously because multiple different encryption mechanisms are employed.
 

--- a/example/create-account.js
+++ b/example/create-account.js
@@ -14,7 +14,7 @@ Example script to create an OpenToken account.
 
 Usage:
 
-    create-login [OPTIONS]
+    create-account [OPTIONS]
 
 Options:
 

--- a/example/signed-request.sh
+++ b/example/signed-request.sh
@@ -15,7 +15,7 @@
 #/ $1     - HTTP verb to use.
 #/ $2     - Path you're accessing.
 #/ $3     - Optional, the content-type for the data.
-#/ stdin  - Data is passed in via stdin.
+#/ $4     - If $3 is set, this defines the file source for the data.
 #/ stdout - Resulting response body is sent out this way.
 #/ stderr - Headers and debug information.
 #/
@@ -71,15 +71,10 @@ arrayContainsValue() {
 # Example
 #
 #   trap deleteTempFile EXIT
-#   tempFileBody=$(mktemp)
 #   tempFileSignature=$(mktemp)
 #
 # Returns nothing.
 deleteTempFile() {
-    if [[ -n "$tempFileBody" ]]; then
-        rm "$tempFileBody"
-    fi
-
     if [[ -n "$tempFileSignature" ]]; then
         rm "$tempFileSignature"
     fi
@@ -135,7 +130,18 @@ fi
 dateStr=$(date --iso-8601=seconds)
 verb=$1
 path=$2
-contentType=${3:-application/octet-stream}
+contentType=text/plain
+fileBody=
+
+if [[ -n "${3-}" ]]; then
+    contentType=$3
+    fileBody=$4
+
+    if [[ ! -f "$fileBody" ]]; then
+        echo "$fileBody is not a file" >&2
+        exit 1
+    fi
+fi
 
 # Determine the protocol and host
 protocol=${OPENTOKEN_API%//*}
@@ -158,10 +164,6 @@ path=${path:0:${#path}-(${#queryString}+${#querySep})}
 
 trap deleteTempFile EXIT
 tempFileSignature=$(mktemp)
-tempFileBody=$(mktemp)
-
-# Capture stdin for the body of the request
-cat > "$tempFileBody"
 
 # Make the content we wish to sign
 {
@@ -172,7 +174,10 @@ cat > "$tempFileBody"
     echo "content-type:$contentType"
     echo "x-opentoken-date:$dateStr"
     echo ""
-    cat "$tempFileBody"
+
+    if [[ -n "$fileBody" ]]; then
+        cat "$fileBody"
+    fi
 } >> "$tempFileSignature"
 
 # Sign the content and ensure it is a lowercase hex string
@@ -185,7 +190,7 @@ curlCmd+=(-H "host: $host")
 curlCmd+=(-H "x-opentoken-date: $dateStr")
 curlCmd+=(-H "content-type: $contentType")
 curlCmd+=(-H "Authorization: OT1-HMAC-SHA256-HEX; access-code=$OPENTOKEN_CODE; signed-headers=host content-type x-opentoken-date; signature=$signature")
-curlCmd+=(--data-binary "@$tempFileBody")
+curlCmd+=(--data-binary "@$fileBody")
 curlCmd+=("$protocol//$host$path$querySep$queryString")
 
 if [[ -n "${DEBUG-}" ]]; then

--- a/lib/middleware/validate-signature-middleware.js
+++ b/lib/middleware/validate-signature-middleware.js
@@ -84,7 +84,7 @@ module.exports = (config, errorResponse, OtDate, promise, signatureOt1) => {
 
                 value = value.substr(1).replace(/" *$/, "");
             } else {
-                // Trim whitespace at the end.
+                // Trim whitespace only at the end.
                 value = value.replace(/ *$/, "");
             }
 
@@ -107,16 +107,23 @@ module.exports = (config, errorResponse, OtDate, promise, signatureOt1) => {
      * @return {Promise.<*>}
      */
     function authenticateSignatureAsync(req, headerValue) {
-        var chunks;
+        var chunks, signatureChunk;
 
         // This works because semicolons are not allowed in the first
         // chunk.  Semicolons may appear in any of the key/value pairs
         // and that's handled in parseHeaderKeyValuePairs().
         chunks = headerValue.split(";");
+        signatureChunk = chunks.shift();
+
+        if (signatureChunk) {
+            signatureChunk = signatureChunk.trim();
+        } else {
+            signatureChunk = "";
+        }
 
         // Get the signature type, method, algorithm and encoding from
         // the first chunk.
-        return parseSignatureInformationAsync(chunks.shift().trim()).then((signatureInfo) => {
+        return parseSignatureInformationAsync(signatureChunk).then((signatureInfo) => {
             // Parse the rest of the chunks into key/value pairs
             return parseHeaderKeyValuePairsAsync(chunks).then((kvPairs) => {
                 switch (signatureInfo.type) {

--- a/lib/signature-ot1.js
+++ b/lib/signature-ot1.js
@@ -47,7 +47,13 @@ module.exports = (accessCodeManager, errorResponse, hash, promise, util) => {
 
         for (i = 0; i < signedHeaders.length; i += 1) {
             headerName = signedHeaders[i];
-            value = req.headers[headerName].trim();
+            value = req.headers[headerName];
+
+            if (value) {
+                value = value.trim();
+            } else {
+                value = "";
+            }
 
             if (headerName === "host") {
                 // The Host header must be changed to lowercase because
@@ -224,7 +230,13 @@ module.exports = (accessCodeManager, errorResponse, hash, promise, util) => {
             // Sanitize the signed headers and convert to an array, then
             // ensure our minimum standard for headers is included in the
             // signature.
-            signedHeaders = kvPairs["signed-headers"].toLowerCase().trim().split(/ +/);
+            signedHeaders = kvPairs["signed-headers"];
+
+            if (signedHeaders) {
+                signedHeaders = signedHeaders.toLowerCase().trim().split(/ +/);
+            } else {
+                signedHeaders = [];
+            }
 
             return checkSignedHeadersAsync(signedHeaders);
         }).then(() => {


### PR DESCRIPTION
It was possible to have `.trim()` operate on a non-string before, so I
introduced checks to ensure I have a value instead of `undefined.

Fixed the wording in the documentation.

Updated an example script to have the right permissions and to not read
from stdin any longer.