### PR TITLE
Various fixes to eliminate errors of multiple types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ nbproject/
 /node_modules/
 npm-debug.log
 encryption.key
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/config.json
+++ b/config.json
@@ -134,10 +134,9 @@
         "storagePrefix": "session/"
     },
     "server": {
-        "baseUrl": "https://localhost:8443",
+        "baseUrl": "https://api.opentoken.io",
         "exceptionIdLength": 12,
-        "name": "OpenToken.io",
-        "port": 8443,
+        "port": 8080,
         "profileMiddleware": false,
         "proxyProtocol": false
     },
@@ -148,14 +147,14 @@
         "dateWindowPast": {
             "minutes": 5
         },
-        "host": "localhost:8443",
+        "host": "api.opentoken.io",
         "method": "OT1-HMAC-SHA256-HEX",
-        "relatedLink": "insert-url-here-for-related-link"
+        "relatedLink": "http://opentoken.io/request-signature/"
     },
     "storage": {
         "engine": "s3",
         "s3": {
-            "bucket": "opentoken-io-test-s3",
+            "bucket": "opentoken-io-api",
             "region": "us-east-1"
         }
     },

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,0 +1,41 @@
+Deployment to Elastic Beanstalk
+===============================
+
+Tools required:
+
+* git
+* gpg
+* node and npm
+* zip
+
+This guide is a bit terse and assumes that your hard drive is encrypted.  We don't want encryption keys leaking out to the world because a laptop was stolen.
+
+1. Clone the repository somewhere new.
+
+        git clone https://github.com/opentoken-io/opentoken.git release
+
+2. Install modules.
+
+        cd release
+        npm install
+
+3. Decrypt the encryption key.
+
+        gpg --decrypt encryption.key.asc > encryption.key
+
+4. Make sure tests pass.
+
+        npm test
+
+5. If that fails, **stop here**.
+6. Create an archive.
+
+        zip -r9 ../opentoken-$(date --utc +"%Y-%m-%d-%H-%M-%S").zip * .[^.]* --exclude .git/\* --exclude coverage/\*
+
+7. Login to the [AWS Console](https://opentoken-io.signin.aws.amazon.com/console).
+8. Upload the archive to Elastic Beanstalk.
+9. Wipe the release folder or at least delete `encryption.key`.
+
+Isn't it sweet using AWS for deployment?
+
+This whole process can be automated as well, but that's a task for another day.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,0 +1,57 @@
+Getting Started
+===============
+
+To use the API you must first sign up for it.  There's scripts in the [`../example/`](../example/) folder that will help you out.
+
+
+Creating an Account
+-------------------
+
+This process is the most labor-intensive, but you can do this in under a minute.
+
+    cd example
+    unset HISTFILE  # Turn off shell history so your password isn't stored
+    ./create-account.js --email=your_email@example.com \
+        --password=REALLY_GOOD_PASSWORD
+
+This initiates the account setup.  You will get the MFA seed and you will need that seed in the future.  From here you will need to check your email for a link to validate your account.
+
+    curl /registration/xxxxxxxxxx/confirm/yyyyyyyyyy
+
+This retrieves the account ID.  Save it.  This is pretty important, just like your password and the MFA seed.
+
+
+Creating API Keys
+-----------------
+
+API keys are necessary in order to tokenize information.
+
+    cd examples   # In case you were not there before
+    unset HISTFILE  # Turn off shell history so your password isn't stored
+    ./create-api-keys.js --account=ACCOUNT_ID \
+        --description="Your description for these keys" \
+        --mfa=THE_MFA_SEED --password=REALLY_GOOD_PASSWORD
+
+This will just spit out a set of keys.  They consist of a code and a secret.  The code can be shared with others but keep the secret private!  The secret is used for signing requests.
+
+
+Tokenization, Detokenization
+----------------------------
+
+Signing a request to OpenToken.io is easier than AWS but based on the same principles.  There's a great request to do this for you as well.  Let's tokenize the file `tokenize-me.txt`.
+
+    cd examples   # In case you were not there before
+    unset HISTFILE  # Turn off shell history so your password isn't stored
+    export OPENTOKEN_CODE=YOUR_API_CODE
+    export OPENTOKEN_SECRET=YOUR_API_SECRET
+    ./signed-request POST /account/ACCOUNT_ID/token/ text/plain tokenize-me.txt
+
+This will write out the response.  Inside there will be a `Location` header, with the appropriate portions changed into real IDs.
+
+    Location: /account/ACCOUNT_ID/token/zzzzzzzzz
+
+To retrieve a token you issue a similar signed request
+
+    ./signed-request GET /account/ACCOUNT_ID/token/zzzzzzzzzz > content.txt
+
+

--- a/doc/strength-and-numbers.md
+++ b/doc/strength-and-numbers.md
@@ -62,7 +62,7 @@ In order to attack the algorithms used and without knowing any other weaknesses,
 
 First, we must break AES.  The key size that is used is 32 bytes.  That's 2^256 possibilities, which is about 1.16E77.  With the above supercomputer we can fully scan the keyspace in 4E58 years.  Really, we'd only have to scan about half of that in order to get a 50% chance of finding the key.  Assuming each atom of Earth was one of these supercomputers, it would still take 298,579,912 years to find it.
 
-Whirlpool uses a similarly sized key of 32 bytes.  Again, the number of possibilities for scanning the entire keyspace are the same.  Because it's implemented slower, the supercomputer now takes 1.35E59 years and finally will scan all possibilites after 1 billion years (with a 50% chance after 500 million years).
+Whirlpool uses a similarly sized key of 32 bytes.  Again, the number of possibilities for scanning the entire keyspace are the same.  Because it's implemented slower, the supercomputer now takes 1.35E59 years.  The "every atom of Earth is a supercomputer" would scan all possibilities after 1 billion years (with a 50% chance after 500 million years).
 
 Because the records are stored as double-encrypted payloads, even huge advances in bypassing some of the encryption will not help tremendously because multiple different encryption mechanisms are employed.
 

--- a/example/create-account.js
+++ b/example/create-account.js
@@ -14,7 +14,7 @@ Example script to create an OpenToken account.
 
 Usage:
 
-    create-login [OPTIONS]
+    create-account.js [OPTIONS]
 
 Options:
 

--- a/example/create-api-keys.js
+++ b/example/create-api-keys.js
@@ -14,7 +14,7 @@ Example script to create a set of API keys for OpenToken.
 
 Usage:
 
-    create-api-keys [OPTIONS]
+    create-api-keys.js [OPTIONS]
 
 Options:
 

--- a/example/example-lib.js
+++ b/example/example-lib.js
@@ -188,6 +188,10 @@ function config(args) {
 
         val = process.env[`OPENTOKEN_${name.toUpperCase()}`];
 
+        if (name === "api" && !val) {
+            val = "https://api.opentoken.io";
+        }
+
         if (args[`--${name}`]) {
             val = args[`--${name}`];
         }

--- a/lib/middleware/validate-signature-middleware.js
+++ b/lib/middleware/validate-signature-middleware.js
@@ -84,7 +84,7 @@ module.exports = (config, errorResponse, OtDate, promise, signatureOt1) => {
 
                 value = value.substr(1).replace(/" *$/, "");
             } else {
-                // Trim whitespace at the end.
+                // Trim whitespace only at the end.
                 value = value.replace(/ *$/, "");
             }
 
@@ -107,16 +107,17 @@ module.exports = (config, errorResponse, OtDate, promise, signatureOt1) => {
      * @return {Promise.<*>}
      */
     function authenticateSignatureAsync(req, headerValue) {
-        var chunks;
+        var chunks, signatureChunk;
 
         // This works because semicolons are not allowed in the first
         // chunk.  Semicolons may appear in any of the key/value pairs
         // and that's handled in parseHeaderKeyValuePairs().
         chunks = headerValue.split(";");
+        signatureChunk = chunks.shift().trim();
 
         // Get the signature type, method, algorithm and encoding from
         // the first chunk.
-        return parseSignatureInformationAsync(chunks.shift().trim()).then((signatureInfo) => {
+        return parseSignatureInformationAsync(signatureChunk).then((signatureInfo) => {
             // Parse the rest of the chunks into key/value pairs
             return parseHeaderKeyValuePairsAsync(chunks).then((kvPairs) => {
                 switch (signatureInfo.type) {

--- a/lib/signature-ot1.js
+++ b/lib/signature-ot1.js
@@ -28,7 +28,7 @@
  * @property {string} type Signature type (OT1)
  */
 
-module.exports = (accessCodeManager, errorResponse, hash, promise, util) => {
+module.exports = (accessCodeManager, binaryBuffer, errorResponse, hash, promise, util) => {
     /**
      * Builds the large string to sign.
      *
@@ -59,7 +59,12 @@ module.exports = (accessCodeManager, errorResponse, hash, promise, util) => {
         }
 
         result.push("");
-        result.push(req.body);
+
+        if (req.body) {
+            result.push(binaryBuffer.toString(req.body));
+        } else {
+            result.push("");
+        }
 
         return result.join("\n");
     }

--- a/route/account/_account-id/token/_token-id/index.js
+++ b/route/account/_account-id/token/_token-id/index.js
@@ -21,6 +21,7 @@ module.exports = (server, path, options) => {
                             });
 
                             res.header("Content-Type", tokenRecord.contentType);
+                            res.header("Content-Length", tokenRecord.data.length);
                             res.send(200, tokenRecord.data);
                         } else {
                             res.send(403);

--- a/route/health-check/index.js
+++ b/route/health-check/index.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = (server, pathUrl, options) => {
+    return options.container.call(() => {
+        return {
+            get(req, res, next) {
+                res.send(200, {
+                    status: "healthy"
+                });
+                next();
+            },
+            name: "health-check"
+        };
+    });
+};

--- a/route/index.js
+++ b/route/index.js
@@ -21,6 +21,10 @@ module.exports = (server, pathUrl, options) => {
                             title: "account-login"
                         },
                         {
+                            href: server.router.render("health-check"),
+                            title: "health-check"
+                        },
+                        {
                             href: server.router.render("registration-register"),
                             profile: "/schema/registration/register-request.json",
                             title: "registration-register"

--- a/schema/config/server.json
+++ b/schema/config/server.json
@@ -18,10 +18,6 @@
             "type": "string",
             "minLength": 1
         },
-        "name": {
-            "type": "string",
-            "minLength": 1
-        },
         "port": {
             "type": "integer",
             "minimum": 1,
@@ -44,6 +40,13 @@
             "type": "object"
         }
     },
+    "required": [
+        "baseUrl",
+        "exceptionIdLength",
+        "port",
+        "profileMiddleware",
+        "proxyProtocol"
+    ],
     "allOf": [
         {
             "description": "Define both certificateFile and keyFile or neither",

--- a/spec/mock/binary-buffer-mock.js
+++ b/spec/mock/binary-buffer-mock.js
@@ -13,7 +13,7 @@ module.exports = () => {
     });
 
     mock.toString.andCallFake((params) => {
-        return params.toString();
+        return params.toString("binary");
     });
 
     return mock;

--- a/spec/route/health-check/index.spec.js
+++ b/spec/route/health-check/index.spec.js
@@ -1,0 +1,19 @@
+"use strict";
+
+jasmine.routeTester("/health-check/", null, (routeTester) => {
+    it("exports GET and a name", () => {
+        expect(Object.keys(routeTester.exports).sort()).toEqual([
+            "get",
+            "name"
+        ]);
+    });
+    describe("GET", () => {
+        it("says all is well", () => {
+            return routeTester.get().then(() => {
+                expect(routeTester.res.send).toHaveBeenCalledWith(200, {
+                    status: "healthy"
+                });
+            });
+        });
+    });
+});

--- a/spec/route/index.spec.js
+++ b/spec/route/index.spec.js
@@ -24,6 +24,11 @@ jasmine.routeTester("/", null, (routeTester) => {
                         title: "account-login"
                     },
                     {
+                        href: "rendered route: health-check",
+                        rel: "service",
+                        title: "health-check"
+                    },
+                    {
                         href: "rendered route: registration-register",
                         profile: "/schema/registration/register-request.json",
                         rel: "service",


### PR DESCRIPTION
It was possible to have `.trim()` operate on a non-string before, so I
introduced checks to ensure I have a value instead of `undefined.

Fixed the wording in the documentation.

Updated an example script to have the right permissions and to not read
from stdin any longer.

Fixed where request.body may be a Buffer and it should be changed to a
binary string instead of a UTF-8 encoded string (UTF-8 is the default
when typecasting Buffers to strings).

Ignore Elastic Beanstalk CLI config files.

Added deployment instructions.

Updated config to work as the production config.

Added a specialized health check route.

Removed an unnecessary property from the config.

Prevent nginx from logging requests.

Using Mac-acceptable flags for the date command.