### PR TITLE
Renaming lib/dependencies.js to lib/container.js

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
-
 "use strict";
 
 var config, container, logger;
 
-container = require("../lib/dependencies");
+container = require("../lib/container");
 
 // Initialize the server
 config = container.resolve("config");

--- a/debug/test-hash-compare.js
+++ b/debug/test-hash-compare.js
@@ -6,19 +6,21 @@ var against, bad, container, good, goodSmall, options, secureHash, size;
 options = process.argv.slice(2);
 
 if (options.length < 1) {
-    console.log("Test Hash Comparison \n");
-    console.log("Usage: ./test-hash-compare.js timeToRunFor [iterations]\n");
-    console.log("timeToRunFor: time the test will run in seconds");
-    console.log("iterations: how many times to run through the tests, default is 2");
+    console.log(`Test Hash Comparison
+
+Usage: ./test-hash-compare.js timeToRunFor [iterations]
+
+timeToRunFor: time the test will run in seconds.
+iterations: how many times to run through the tests, default is 2.`);
 
     return;
 }
 
 console.log("Setting Up...");
-
-container = require("../lib/dependencies");
+container = require("../lib/container");
 secureHash = container.resolve("secureHash");
 
+// Create some buffers
 size = 1024 * 16;
 against = new Buffer(size);
 against.fill(0x42);

--- a/lib/container.js
+++ b/lib/container.js
@@ -11,13 +11,10 @@ container.register("container", container);
 // Configuration - uses `.provide()` because there is no injection
 container.register("config", "../config.json").fromModule(__dirname);
 
-// Here's a way we can promisify modules in bulk
-container.register("promisifier", "./promisifier").fromModule(__dirname).asFactory().cached();
-
 // Our code is most often written as factories.
 // Register a bunch as
 // container.register(fileNameCamelCase, "file-name")
-//     .fromModule(__dirname).asFactory.cached();
+//     .fromModule(__dirname).asFactory().cached();
 // The key is the name in the container, the value is the name of the file.
 moduleDefs = {
     accessCodeManager: "./manager/access-code-manager",
@@ -50,6 +47,7 @@ moduleDefs = {
     MiddlewareProfiler: "./middleware-profiler",
     OtDate: "./ot-date",
     promise: "./promise",
+    promisifier: "./promisifier",
     random: "./random",
     readBodyBufferMiddleware: "./middleware/read-body-buffer-middleware",
     record: "./record",
@@ -61,6 +59,7 @@ moduleDefs = {
     signatureOt1: "./signature-ot1",
     storage: "./storage",
     storageServiceFactory: "./storage-service-factory",
+    template: "./template",
     textFormatter: "./formatter/text-formatter",
     tokenManager: "./manager/token-manager",
     totp: "./mfa/totp",
@@ -86,10 +85,12 @@ moduleDefs = {
     bluebird: "bluebird",
     bufferSerializerModule: "buffer-serializer",
     crypto: "crypto",
+    docopt: "docopt",
     fs: "fs",
     glob: "glob",
     helmet: "helmet",
     moment: "moment",
+    mustache: "mustache",
     path: "path",
     proxywrap: "findhit-proxywrap",
     restify: "restify",

--- a/spec/bin/server.spec.js
+++ b/spec/bin/server.spec.js
@@ -31,7 +31,7 @@ describe("bin/server.js", () => {
                 info() {}
             }
         };
-        mockRequire("../../lib/dependencies", {
+        mockRequire("../../lib/container", {
             resolve(thing) {
                 return containerResults[thing];
             }

--- a/spec/helper/formatter-to-promise.helper.js
+++ b/spec/helper/formatter-to-promise.helper.js
@@ -22,7 +22,7 @@ jasmine.formatterToPromise = (formatterName, reqMock, resMock) => {
         resMock = require("../mock/response-mock")();
     }
 
-    container = require("../../lib/dependencies");
+    container = require("../../lib/container");
     errorResponseMock = require("../mock/error-response-mock")();
     genericFormatterMock = require("../mock/formatter/generic-formatter-mock")();
     container.register("errorResponse", errorResponseMock);

--- a/spec/helper/route-tester.helper.js
+++ b/spec/helper/route-tester.helper.js
@@ -102,7 +102,7 @@ jasmine.routeTester = (routePath, containerOverrideFn, callback) => {
             beforeEach(() => {
                 var config, container, serverMock;
 
-                container = require("../../lib/dependencies");
+                container = require("../../lib/container");
                 config = container.resolve("config");
                 config.baseDir = "/";
                 container.register("config", config);

--- a/spec/lib/buffer-serializer.spec.js
+++ b/spec/lib/buffer-serializer.spec.js
@@ -6,7 +6,7 @@ describe("bufferSerializer", () => {
     beforeEach(() => {
         var container;
 
-        container = require("../../lib/dependencies");
+        container = require("../../lib/container");
         OtDate = container.resolve("OtDate");
         bufferSerializer = container.resolve("bufferSerializer");
     });

--- a/spec/lib/container.spec.js
+++ b/spec/lib/container.spec.js
@@ -1,10 +1,10 @@
 "use strict";
 
-describe("dependencies", () => {
+describe("container", () => {
     var container;
 
     beforeEach(() => {
-        container = require("../../lib/dependencies");
+        container = require("../../lib/container");
     });
     it("returns an object", () => {
         expect(container).toEqual(jasmine.any(Object));

--- a/spec/lib/manager/registration-manager.spec.js
+++ b/spec/lib/manager/registration-manager.spec.js
@@ -27,10 +27,9 @@ describe("registrationManager", () => {
             passwordHashConfig: "passwordHashConfig"
         }));
         totpMock = require("../../mock/mfa/totp-mock")();
-        factory = (override) => {
+        factory = () => {
             var config;
 
-            override = override || {};
             config = {
                 account: {},
                 registration: {

--- a/spec/lib/middleware-profiler.spec.js
+++ b/spec/lib/middleware-profiler.spec.js
@@ -64,6 +64,7 @@ describe("MiddlewareProfiler", () => {
                  * @param {Object} req Request
                  * @param {Object} res Response
                  * @param {Function} next
+                 * @return {number} irrelevant
                  */
                 function fakeMiddleware(req, res, next) {
                     var i, start;
@@ -77,6 +78,11 @@ describe("MiddlewareProfiler", () => {
                     }
 
                     next();
+
+                    /* Returning the value so ESLint is tricked into
+                     * thinking the variable is used.
+                     */
+                    return i;
                 }
 
                 /**

--- a/spec/mock/middleware/validate-request-body-middleware-mock.js
+++ b/spec/mock/middleware/validate-request-body-middleware-mock.js
@@ -2,7 +2,7 @@
 
 var container;
 
-container = require("../../../lib/dependencies");
+container = require("../../../lib/container");
 
 module.exports = () => {
     var middleware, middlewareFactory;

--- a/spec/mock/middleware/validate-request-query-middleware-mock.js
+++ b/spec/mock/middleware/validate-request-query-middleware-mock.js
@@ -2,7 +2,7 @@
 
 var container;
 
-container = require("../../../lib/dependencies");
+container = require("../../../lib/container");
 
 module.exports = () => {
     var middleware, middlewareFactory;


### PR DESCRIPTION
This returns a configured container, so the new name seems to fit better.

Includes fixes for ESLint.