### PR TITLE
Fixing the HTTP status to be 201 Created

### DIFF
--- a/route/account/_account-id/token/index.js
+++ b/route/account/_account-id/token/index.js
@@ -38,7 +38,7 @@ module.exports = (server, path, options) => {
                                 title: "account"
                             }
                         });
-                        res.send(204);
+                        res.send(201);
                     }).then(next, next);
                 }
             ]

--- a/spec/route/account/_account-id/token/index.spec.js
+++ b/spec/route/account/_account-id/token/index.spec.js
@@ -111,8 +111,8 @@ jasmine.routeTester("/account/_account-id/token/", (container) => {
                     }
                 ], routeTester.res.linkObjects);
             });
-            it("resulted in a 204 (very important)", () => {
-                expect(routeTester.res.send).toHaveBeenCalledWith(204);
+            it("resulted in a 201 (very important)", () => {
+                expect(routeTester.res.send).toHaveBeenCalledWith(201);
             });
         });
     });


### PR DESCRIPTION
This is more fitting than a 204.  There's nothing in the spec that says
201 must have a representation of the resource.  Also, 204 is more
general and can apply to more situations than 201.